### PR TITLE
Implement HTTP Basic Authentication

### DIFF
--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -17,6 +17,7 @@ AUTH_MANAGER_MAPPING = {
 }
 SUCCESSFUL_LOGIN_MESSAGE = "Successfully logged in"
 SUCCESSFUL_LOGOUT_MESSAGE = "Successfully logged out"
+SUCCESSFUL_COLOR = "green"
 MAX_LOGIN_ATTEMPTS = 3
 
 
@@ -104,7 +105,7 @@ def login(channel: Channel, **kwargs):
             if attempts >= MAX_LOGIN_ATTEMPTS:
                 raise CondaAuthError(f"Max attempts reached; {exc}")
 
-    click.echo(click.style(SUCCESSFUL_LOGIN_MESSAGE, fg="green"))
+    click.echo(click.style(SUCCESSFUL_LOGIN_MESSAGE, fg=SUCCESSFUL_COLOR))
 
     try:
         condarc = CondaRC()
@@ -129,4 +130,4 @@ def logout(channel: Channel):
     auth_type, auth_manager = get_auth_manager(settings)
     auth_manager.remove_secret(channel, settings)
 
-    click.echo(click.style(SUCCESSFUL_LOGOUT_MESSAGE, fg="green"))
+    click.echo(click.style(SUCCESSFUL_LOGOUT_MESSAGE, fg=SUCCESSFUL_COLOR))

--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -100,19 +100,15 @@ def login(channel: Channel, **kwargs):
 
 
 @group.command("logout")
-@click.option("-u", "--username")
 @click.argument("channel", callback=parse_channel)
-def logout(channel: Channel, **kwargs):
+def logout(channel: Channel):
     """
     Logout of a channel
     """
-    kwargs = {key: val for key, val in kwargs.items() if val is not None}
     settings = get_channel_settings(channel.canonical_name)
 
     if settings is None:
         raise CondaAuthError("Unable to find information about logged in session.")
-
-    settings.update(kwargs)
 
     settings["type"] = settings["auth"]
     auth_type, auth_manager = get_auth_manager(settings)

--- a/conda_auth/condarc.py
+++ b/conda_auth/condarc.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from ruamel.yaml import YAML, YAMLError
+
+yaml = YAML()
+
+
+class CondaRCError(Exception):
+    pass
+
+
+class CondaRC:
+    def __init__(self):
+        """
+        Initializes the CondaRC object by attempting to open and load the contents
+        of the condarc file found in the user's home directory.
+        """
+        self.condarc_path = Path(os.path.expanduser("~/.condarc"))
+
+        try:
+            self.condarc_path.touch()
+            with self.condarc_path.open("r") as fp:
+                contents = fp.read()
+        except OSError as exc:
+            raise CondaRCError(f"Could not open condarc file: {exc}")
+
+        try:
+            self.loaded_yaml = yaml.load(contents)
+        except YAMLError as exc:
+            raise CondaRCError(f"Could not parse condarc: {exc}")
+
+    def update_channel_settings(self, channel: str, username: str, auth_type: str):
+        """
+        Update the condarc file's "channel_settings" section
+        """
+        updated_settings = {"channel": channel, "auth": auth_type, "username": username}
+
+        channel_settings = self.loaded_yaml.get("channel_settings", [])
+
+        # Filter out the existing channel's entry if it's there
+        filter_settings = [
+            settings
+            for settings in channel_settings
+            if settings.get("channel") != channel
+        ]
+
+        # Add the updated settings map
+        filter_settings.append(updated_settings)
+
+        self.loaded_yaml["channel_settings"] = filter_settings
+
+    def save(self):
+        """Save the condarc file"""
+        try:
+            with self.condarc_path.open("w") as fp:
+                yaml.dump(self.loaded_yaml, fp)
+        except OSError as exc:
+            raise CondaRCError(f"Could not save file: {exc}")

--- a/conda_auth/condarc.py
+++ b/conda_auth/condarc.py
@@ -38,7 +38,7 @@ class CondaRC:
         """
         updated_settings = {"channel": channel, "auth": auth_type, "username": username}
 
-        channel_settings = self.loaded_yaml.get("channel_settings", [])
+        channel_settings = self.loaded_yaml.get("channel_settings", []) or []
 
         # Filter out the existing channel's entry if it's there
         filter_settings = [

--- a/conda_auth/condarc.py
+++ b/conda_auth/condarc.py
@@ -13,12 +13,12 @@ class CondaRCError(Exception):
 
 
 class CondaRC:
-    def __init__(self):
+    def __init__(self, condarc_path: Path | None = None):
         """
         Initializes the CondaRC object by attempting to open and load the contents
         of the condarc file found in the user's home directory.
         """
-        self.condarc_path = Path(os.path.expanduser("~/.condarc"))
+        self.condarc_path = condarc_path or Path(os.path.expanduser("~/.condarc"))
 
         try:
             self.condarc_path.touch()
@@ -28,7 +28,7 @@ class CondaRC:
             raise CondaRCError(f"Could not open condarc file: {exc}")
 
         try:
-            self.loaded_yaml = yaml.load(contents)
+            self.loaded_yaml = yaml.load(contents) or {}
         except YAMLError as exc:
             raise CondaRCError(f"Could not parse condarc: {exc}")
 

--- a/conda_auth/constants.py
+++ b/conda_auth/constants.py
@@ -5,10 +5,10 @@ A place for all of our constant variables
 PLUGIN_NAME = "conda-auth"
 
 # move to the handlers module
-OAUTH2_NAME = f"{PLUGIN_NAME}-oauth2"
+OAUTH2_NAME = "oauth2"
 
 # move to the handlers module
-HTTP_BASIC_AUTH_NAME = f"{PLUGIN_NAME}-basic-auth"
+HTTP_BASIC_AUTH_NAME = "http-basic"
 
 # Error messages
 LOGOUT_ERROR_MESSAGE = "Unable to logout."

--- a/conda_auth/exceptions.py
+++ b/conda_auth/exceptions.py
@@ -3,3 +3,7 @@ from conda.exceptions import CondaError
 
 class CondaAuthError(CondaError):
     """Custom error for the conda-auth plugin"""
+
+
+class InvalidCredentialsError(CondaAuthError):
+    """Error raised when credentials are invalid"""

--- a/conda_auth/handlers/base.py
+++ b/conda_auth/handlers/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 
 import conda.base.context
 import keyring
@@ -39,7 +40,7 @@ class AuthManager(ABC):
                 ):
                     self.authenticate(channel, settings)
 
-    def authenticate(self, channel: Channel, settings: dict[str, str]) -> str:
+    def authenticate(self, channel: Channel, settings: Mapping[str, str]) -> str:
         """Used to retrieve credentials and store them on the ``cache`` property"""
         extra_params = {
             param: settings.get(param) for param in self.get_config_parameters()
@@ -63,7 +64,7 @@ class AuthManager(ABC):
         )
 
     def fetch_secret(
-        self, channel: Channel, settings: dict[str, str | None]
+        self, channel: Channel, settings: Mapping[str, str | None]
     ) -> tuple[str, str]:
         """
         Fetch secrets and handle updating cache.
@@ -89,12 +90,12 @@ class AuthManager(ABC):
 
     @abstractmethod
     def _fetch_secret(
-        self, channel: Channel, settings: dict[str, str | None]
+        self, channel: Channel, settings: Mapping[str, str | None]
     ) -> tuple[str, str]:
         """Implementations should include routine for fetching secret"""
 
     @abstractmethod
-    def remove_secret(self, channel: Channel, settings: dict[str, str | None]) -> None:
+    def remove_secret(self, channel: Channel, settings: Mapping[str, str]) -> None:
         """Implementations should include routine for removing secret"""
 
     @abstractmethod

--- a/conda_auth/handlers/basic_auth.py
+++ b/conda_auth/handlers/basic_auth.py
@@ -4,6 +4,7 @@ Basic auth implementation for the conda auth handler plugin hook
 from __future__ import annotations
 
 from getpass import getpass
+from collections.abc import Mapping
 
 import keyring
 from keyring.errors import PasswordDeleteError
@@ -27,7 +28,7 @@ class BasicAuthManager(AuthManager):
         return f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel_name}"
 
     def _fetch_secret(
-        self, channel: Channel, settings: dict[str, str | None]
+        self, channel: Channel, settings: Mapping[str, str | None]
     ) -> tuple[str, str]:
         """
         Gets the secrets by checking the keyring and then falling back to interrupting
@@ -38,7 +39,9 @@ class BasicAuthManager(AuthManager):
 
         return username, password
 
-    def remove_secret(self, channel: Channel, settings: dict[str, str | None]) -> None:
+    def remove_secret(
+        self, channel: Channel, settings: Mapping[str, str | None]
+    ) -> None:
         keyring_id = self.get_keyring_id(channel.canonical_name)
         username = self.get_username(settings, channel)
 
@@ -66,7 +69,7 @@ class BasicAuthManager(AuthManager):
         print(f"Please provide credentials for channel: {channel.canonical_name}")
         return input("Username: ")
 
-    def get_username(self, settings: dict[str, str | None], channel: Channel):
+    def get_username(self, settings: Mapping[str, str | None], channel: Channel):
         """
         Attempts to find username in settings and falls back to prompting user for it if not found.
         """
@@ -78,7 +81,7 @@ class BasicAuthManager(AuthManager):
         return username
 
     def get_password(
-        self, username: str, settings: dict[str, str | None], channel: Channel
+        self, username: str, settings: Mapping[str, str | None], channel: Channel
     ) -> str:
         """
         Attempts to get password and falls back to prompting the user for it if not found.

--- a/conda_auth/handlers/oauth2.py
+++ b/conda_auth/handlers/oauth2.py
@@ -3,6 +3,8 @@ OAuth2 implementation for the conda auth handler plugin hook
 """
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import keyring
 from keyring.errors import PasswordDeleteError
 from conda.base.context import context
@@ -28,7 +30,7 @@ class OAuth2Manager(AuthManager):
         return f"{PLUGIN_NAME}::{OAUTH2_NAME}::{channel_name}"
 
     def _fetch_secret(
-        self, channel: Channel, settings: dict[str, str | None]
+        self, channel: Channel, settings: Mapping[str, str | None]
     ) -> tuple[str, str]:
         """
         Gets the secrets by checking the keyring and then falling back to interrupting
@@ -53,7 +55,9 @@ class OAuth2Manager(AuthManager):
 
         return USERNAME, token
 
-    def remove_secret(self, channel: Channel, settings: dict[str, str | None]) -> None:
+    def remove_secret(
+        self, channel: Channel, settings: Mapping[str, str | None]
+    ) -> None:
         keyring_id = self.get_keyring_id(channel.canonical_name)
 
         try:
@@ -89,7 +93,6 @@ class OAuth2Handler(ChannelAuthBase):
 
     def __init__(self, channel_name: str):
         _, self.token = manager.get_secret(channel_name)
-        breakpoint()
 
         if self.token is None:
             raise CondaError(

--- a/conda_auth/handlers/oauth2.py
+++ b/conda_auth/handlers/oauth2.py
@@ -10,7 +10,7 @@ from conda.exceptions import CondaError
 from conda.models.channel import Channel
 from conda.plugins.types import ChannelAuthBase
 
-from ..constants import OAUTH2_NAME, LOGOUT_ERROR_MESSAGE
+from ..constants import OAUTH2_NAME, LOGOUT_ERROR_MESSAGE, PLUGIN_NAME
 from ..exceptions import CondaAuthError
 from .base import AuthManager
 
@@ -25,7 +25,7 @@ USERNAME = "token"
 
 class OAuth2Manager(AuthManager):
     def get_keyring_id(self, channel_name: str) -> str:
-        return f"{OAUTH2_NAME}::{channel_name}"
+        return f"{PLUGIN_NAME}::{OAUTH2_NAME}::{channel_name}"
 
     def _fetch_secret(
         self, channel: Channel, settings: dict[str, str | None]
@@ -74,6 +74,9 @@ class OAuth2Manager(AuthManager):
         print(f"Follow link to login: {login_url}")
         return input("Copy and paste login token here: ")
 
+    def get_auth_class(self) -> type:
+        return OAuth2Handler
+
 
 manager = OAuth2Manager(context)
 
@@ -86,6 +89,7 @@ class OAuth2Handler(ChannelAuthBase):
 
     def __init__(self, channel_name: str):
         _, self.token = manager.get_secret(channel_name)
+        breakpoint()
 
         if self.token is None:
             raise CondaError(

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - conda-canary/label/dev::conda
   - keyring
   - requests
+  - ruamel.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "conda",
   "keyring",
   "requests",
+  "ruamel.yaml",
 ]
 
 [project.entry-points.conda]

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -1,0 +1,80 @@
+from conda_auth.cli import group
+from conda_auth.exceptions import CondaAuthError
+
+
+def test_login_no_options_basic_auth(mocker, runner, session, keyring, condarc):
+    """
+    Runs the login command with no additional CLI options defined (e.g. --username)
+    """
+    secret = "password"
+    channel_name = "tester"
+
+    keyring(secret)
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [
+        {"channel": channel_name, "auth": "http-basic", "username": "user"}
+    ]
+    mock_getpass = mocker.patch("conda_auth.handlers.basic_auth.getpass")
+    mock_getpass.return_value = secret
+
+    result = runner.invoke(group, ["login", channel_name])
+
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_login_with_options_basic_auth(mocker, runner, session, keyring, condarc):
+    """
+    Runs the login command with CLI options defined (e.g. --username)
+    """
+    channel_name = "tester"
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [{"channel": channel_name, "auth": "http-basic"}]
+
+    keyring(None)
+
+    result = runner.invoke(
+        group, ["login", channel_name, "--username", "test", "--password", "test"]
+    )
+
+    assert result.exit_code == 0
+    assert result.output == ""
+
+
+def test_login_with_invalid_auth_type(mocker, runner, session, keyring, condarc):
+    """
+    Runs the login command when there is an invalid auth type configured in settings
+    """
+    channel_name = "tester"
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [
+        {"channel": channel_name, "auth": "does-not-exist"}
+    ]
+
+    keyring(None)
+
+    result = runner.invoke(group, ["login", channel_name])
+    exc_type, exception, _ = result.exc_info
+
+    assert result.exit_code == 1
+    assert exc_type == CondaAuthError
+    assert "Invalid authentication type." in exception.message
+
+
+def test_login_with_non_existent_channel(mocker, runner, session, keyring, condarc):
+    """
+    Runs the login command for a channel that is not present in the settings file
+    """
+    channel_name = "tester"
+    secret = "password"
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = []
+    mock_getpass = mocker.patch("conda_auth.handlers.basic_auth.getpass")
+    mock_getpass.return_value = secret
+
+    keyring(None)
+
+    result = runner.invoke(group, ["login", channel_name], input="user")
+
+    assert result.exit_code == 0
+    assert result.output == ""

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -1,4 +1,6 @@
 from conda_auth.cli import group
+from conda_auth.condarc import CondaRCError
+from conda_auth.constants import HTTP_BASIC_AUTH_NAME
 from conda_auth.exceptions import CondaAuthError
 
 
@@ -9,14 +11,16 @@ def test_login_no_options_basic_auth(mocker, runner, session, keyring, condarc):
     secret = "password"
     channel_name = "tester"
 
+    # setup mocks
     keyring(secret)
     mock_context = mocker.patch("conda_auth.cli.context")
     mock_context.channel_settings = [
-        {"channel": channel_name, "auth": "http-basic", "username": "user"}
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": "user"}
     ]
     mock_getpass = mocker.patch("conda_auth.handlers.basic_auth.getpass")
     mock_getpass.return_value = secret
 
+    # run command
     result = runner.invoke(group, ["login", channel_name])
 
     assert result.exit_code == 0
@@ -28,11 +32,13 @@ def test_login_with_options_basic_auth(mocker, runner, session, keyring, condarc
     Runs the login command with CLI options defined (e.g. --username)
     """
     channel_name = "tester"
-    mock_context = mocker.patch("conda_auth.cli.context")
-    mock_context.channel_settings = [{"channel": channel_name, "auth": "http-basic"}]
 
+    # setup mocks
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = []
     keyring(None)
 
+    # run command
     result = runner.invoke(
         group, ["login", channel_name, "--username", "test", "--password", "test"]
     )
@@ -46,13 +52,15 @@ def test_login_with_invalid_auth_type(mocker, runner, session, keyring, condarc)
     Runs the login command when there is an invalid auth type configured in settings
     """
     channel_name = "tester"
+
+    # setup mocks
     mock_context = mocker.patch("conda_auth.cli.context")
     mock_context.channel_settings = [
         {"channel": channel_name, "auth": "does-not-exist"}
     ]
-
     keyring(None)
 
+    # run command
     result = runner.invoke(group, ["login", channel_name])
     exc_type, exception, _ = result.exc_info
 
@@ -67,14 +75,42 @@ def test_login_with_non_existent_channel(mocker, runner, session, keyring, conda
     """
     channel_name = "tester"
     secret = "password"
+
+    # setup mocks
     mock_context = mocker.patch("conda_auth.cli.context")
     mock_context.channel_settings = []
     mock_getpass = mocker.patch("conda_auth.handlers.basic_auth.getpass")
     mock_getpass.return_value = secret
-
     keyring(None)
 
+    # run command
     result = runner.invoke(group, ["login", channel_name], input="user")
 
     assert result.exit_code == 0
     assert result.output == ""
+
+
+def test_login_succeeds_error_returned_when_updating_condarc(
+    mocker, runner, session, keyring, condarc
+):
+    """
+    Test the case where the login runs successfully but an error is returned when trying to update
+    the condarc file.
+    """
+    channel_name = "tester"
+    secret = "password"
+
+    # setup mocks
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = []
+    mock_getpass = mocker.patch("conda_auth.handlers.basic_auth.getpass")
+    mock_getpass.return_value = secret
+    keyring(None)
+    condarc().save.side_effect = CondaRCError("Could not save file")
+
+    # run command
+    result = runner.invoke(group, ["login", channel_name], input="user")
+    exc_type, exception, _ = result.exc_info
+
+    assert exc_type == CondaAuthError
+    assert "Could not save file" == exception.message

--- a/tests/cli/test_logout.py
+++ b/tests/cli/test_logout.py
@@ -1,4 +1,4 @@
-from conda_auth.cli import group
+from conda_auth.cli import group, SUCCESSFUL_LOGOUT_MESSAGE
 from conda_auth.constants import HTTP_BASIC_AUTH_NAME, PLUGIN_NAME
 from conda_auth.exceptions import CondaAuthError
 
@@ -21,7 +21,7 @@ def test_logout_of_active_session(mocker, runner, keyring):
     # run command
     result = runner.invoke(group, ["logout", channel_name])
 
-    assert result.output == ""
+    assert SUCCESSFUL_LOGOUT_MESSAGE in result.output
     assert result.exit_code == 0
 
     # Make sure the delete password call was invoked correctly

--- a/tests/cli/test_logout.py
+++ b/tests/cli/test_logout.py
@@ -1,0 +1,49 @@
+from conda_auth.cli import group
+from conda_auth.constants import HTTP_BASIC_AUTH_NAME, PLUGIN_NAME
+from conda_auth.exceptions import CondaAuthError
+
+
+def test_logout_of_active_session(mocker, runner, keyring):
+    """
+    Logs out of currently active session; this essentially just removes the "keyring" entry
+    """
+    channel_name = "tester"
+    secret = "password"
+    username = "user"
+
+    # setup mocks
+    mock_context = mocker.patch("conda_auth.cli.context")
+    keyring_mocks = keyring(secret)
+    mock_context.channel_settings = [
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+    ]
+
+    # run command
+    result = runner.invoke(group, ["logout", channel_name])
+
+    assert result.output == ""
+    assert result.exit_code == 0
+
+    # Make sure the delete password call was invoked correctly
+    assert keyring_mocks.basic.delete_password.mock_calls == [
+        mocker.call(f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel_name}", username)
+    ]
+
+
+def test_logout_of_non_existing_session(mocker, runner, keyring):
+    """
+    Logs out of currently active session; this essentially just removes the "keyring" entry
+    """
+    channel_name = "tester"
+
+    # setup mocks
+    mock_context = mocker.patch("conda_auth.cli.context")
+    keyring(None)
+    mock_context.channel_settings = []
+
+    # run command
+    result = runner.invoke(group, ["logout", channel_name])
+    exc_type, exception, _ = result.exc_info
+
+    assert exc_type == CondaAuthError
+    assert "Unable to find information about logged in session." in exception.message

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 from typing import NamedTuple
 
 import pytest
+from click.testing import CliRunner
 
 
 class KeyringMocks(NamedTuple):
@@ -34,7 +35,7 @@ def session(mocker):
     """
     Used to mock the get_session function from conda to mock network requests
     """
-    session_mock = mocker.patch("conda_auth.handlers.base.get_session")
+    session_mock = mocker.patch("conda_auth.handlers.base.CondaSession")
 
     return session_mock
 
@@ -51,3 +52,21 @@ def getpass(mocker):
         return getpass_mock
 
     return _getpass
+
+
+@pytest.fixture
+def runner():
+    """
+    CLI test runner used for all tests
+    """
+    yield CliRunner()
+
+
+@pytest.fixture
+def condarc(mocker):
+    """
+    Mocks the CondaRC object
+    """
+    condarc_mock = mocker.patch("conda_auth.cli.CondaRC")
+
+    return condarc_mock

--- a/tests/handlers/test_oauth2.py
+++ b/tests/handlers/test_oauth2.py
@@ -1,13 +1,16 @@
-from unittest.mock import MagicMock
-
 import pytest
 from keyring.errors import PasswordDeleteError
 from conda.models.channel import Channel
 
-from conda_auth.handlers import OAuth2Manager
-from conda_auth.handlers.oauth2 import USERNAME
+from conda_auth.handlers.oauth2 import USERNAME, manager
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.constants import LOGOUT_ERROR_MESSAGE, OAUTH2_NAME
+
+
+@pytest.fixture(autouse=True)
+def clean_up_manager_cache():
+    """Makes sure the manager cache gets emptied after each test run"""
+    manager._cache = {}
 
 
 def test_oauth2_manager_no_previous_secret(mocker, session, keyring):
@@ -20,21 +23,19 @@ def test_oauth2_manager_no_previous_secret(mocker, session, keyring):
         "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
-    cache = {}
     channel = Channel("tester")
 
     # setup mocks
     input_mock = mocker.patch("conda_auth.handlers.oauth2.input")
     input_mock.return_value = secret
     keyring(None)
-    context_mock = MagicMock()
+    mocker.patch("conda_auth.handlers.oauth2.context")
 
     # run code under test
-    oauth = OAuth2Manager(context_mock, cache)
-    oauth.authenticate(channel, settings)
+    manager.authenticate(channel, settings)
 
     # make assertions
-    assert oauth._cache == {channel.canonical_name: (USERNAME, secret)}
+    assert manager._cache == {channel.canonical_name: (USERNAME, secret)}
 
 
 def test_oauth2_manager_no_login_url_present(mocker, session, keyring):
@@ -46,22 +47,18 @@ def test_oauth2_manager_no_login_url_present(mocker, session, keyring):
     settings = {
         "auth": OAUTH2_NAME,
     }
-    cache = {}
     channel = Channel("tester")
 
     # setup mocks
     input_mock = mocker.patch("conda_auth.handlers.oauth2.input")
     input_mock.return_value = secret
     keyring(None)
-    context_mock = MagicMock()
-
-    # run code under test
-    oauth2 = OAuth2Manager(context_mock, cache)
+    mocker.patch("conda_auth.handlers.oauth2.context")
 
     with pytest.raises(
         CondaAuthError, match='`login_url` is not set for channel "tester"'
     ):
-        oauth2.authenticate(channel, settings)
+        manager.authenticate(channel, settings)
 
 
 def test_oauth2_manager_with_previous_secret(mocker, session, keyring):
@@ -75,23 +72,22 @@ def test_oauth2_manager_with_previous_secret(mocker, session, keyring):
         "login_url": "http://localhost",
     }
     channel = Channel("tester")
-    cache = {channel.canonical_name: (USERNAME, secret)}
+    manager._cache = {channel.canonical_name: (USERNAME, secret)}
 
     # setup mocks
     input_mock = mocker.patch("conda_auth.handlers.oauth2.input")
     keyring(secret)
-    context_mock = MagicMock()
+    mocker.patch("conda_auth.handlers.oauth2.context")
 
     # run code under test
-    oauth2 = OAuth2Manager(context_mock, cache)
-    oauth2.authenticate(channel, settings)
+    manager.authenticate(channel, settings)
 
     # make assertions
-    assert oauth2._cache == {channel.canonical_name: (USERNAME, secret)}
+    assert manager._cache == {channel.canonical_name: (USERNAME, secret)}
     input_mock.assert_not_called()
 
 
-def test_oauth2_manager_cache_exists(session, keyring, getpass):
+def test_oauth2_manager_cache_exists(session, keyring, getpass, mocker):
     """
     Test to make sure that everything works as expected when a cache entry
     already exists for a credential set.
@@ -103,24 +99,23 @@ def test_oauth2_manager_cache_exists(session, keyring, getpass):
         "login_url": "http://localhost",
     }
     channel = Channel("tester")
-    cache = {channel.canonical_name: (username, secret)}
+    manager._cache = {channel.canonical_name: (username, secret)}
 
     # setup mocks
     getpass_mock = getpass(secret)
     keyring_mock = keyring(secret)
-    context_mock = MagicMock()
+    mocker.patch("conda_auth.handlers.oauth2.context")
 
     # run code under test
-    oauth2 = OAuth2Manager(context_mock, cache)
-    oauth2.authenticate(channel, settings)
+    manager.authenticate(channel, settings)
 
     # make assertions
-    assert oauth2._cache == {channel.canonical_name: (username, secret)}
+    assert manager._cache == {channel.canonical_name: (username, secret)}
     getpass_mock.assert_not_called()
     keyring_mock.basic.get_password.assert_not_called()
 
 
-def test_oauth2_manager_remove_existing_secret(keyring):
+def test_oauth2_manager_remove_existing_secret(keyring, mocker):
     """
     Test to make sure that removing a password that exist works.
     """
@@ -129,22 +124,20 @@ def test_oauth2_manager_remove_existing_secret(keyring):
         "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
-    cache = {}
     channel = Channel("tester")
 
     # setup mocks
     keyring_mocks = keyring(secret)
-    context = MagicMock()
+    mocker.patch("conda_auth.handlers.oauth2.context")
 
     # run code under test
-    oauth2 = OAuth2Manager(context, cache)
-    oauth2.remove_secret(channel, settings)
+    manager.remove_secret(channel, settings)
 
     # make assertions
     keyring_mocks.oauth2.delete_password.assert_called_once()
 
 
-def test_oauth2_manager_remove_non_existing_secret(keyring):
+def test_oauth2_manager_remove_non_existing_secret(keyring, mocker):
     """
     Test make sure that when removing a secret that does not exist, the appropriate
     exception and message is raised and shown.
@@ -154,18 +147,14 @@ def test_oauth2_manager_remove_non_existing_secret(keyring):
         "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
-    cache = {}
     channel = Channel("tester")
 
     # setup mocks
     keyring_mocks = keyring(secret)
     message = "Secret not found."
     keyring_mocks.oauth2.delete_password.side_effect = PasswordDeleteError(message)
-    context = MagicMock()
-
-    # run code under test
-    oauth2 = OAuth2Manager(context, cache)
+    mocker.patch("conda_auth.handlers.oauth2.context")
 
     # make assertions
     with pytest.raises(CondaAuthError, match=f"{LOGOUT_ERROR_MESSAGE} {message}"):
-        oauth2.remove_secret(channel, settings)
+        manager.remove_secret(channel, settings)

--- a/tests/handlers/test_oauth2.py
+++ b/tests/handlers/test_oauth2.py
@@ -7,7 +7,7 @@ from conda.models.channel import Channel
 from conda_auth.handlers import OAuth2Manager
 from conda_auth.handlers.oauth2 import USERNAME
 from conda_auth.exceptions import CondaAuthError
-from conda_auth.constants import LOGOUT_ERROR_MESSAGE
+from conda_auth.constants import LOGOUT_ERROR_MESSAGE, OAUTH2_NAME
 
 
 def test_oauth2_manager_no_previous_secret(mocker, session, keyring):
@@ -17,7 +17,7 @@ def test_oauth2_manager_no_previous_secret(mocker, session, keyring):
     """
     secret = "secret"
     settings = {
-        "auth": "conda-auth-oauth2",
+        "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
     cache = {}
@@ -44,7 +44,7 @@ def test_oauth2_manager_no_login_url_present(mocker, session, keyring):
     """
     secret = "secret"
     settings = {
-        "auth": "conda-auth-oauth2",
+        "auth": OAUTH2_NAME,
     }
     cache = {}
     channel = Channel("tester")
@@ -71,7 +71,7 @@ def test_oauth2_manager_with_previous_secret(mocker, session, keyring):
     """
     secret = "secret"
     settings = {
-        "auth": "conda-auth-oauth2",
+        "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
     channel = Channel("tester")
@@ -99,7 +99,7 @@ def test_oauth2_manager_cache_exists(session, keyring, getpass):
     secret = "secret"
     username = "admin"
     settings = {
-        "auth": "conda-auth-oauth2",
+        "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
     channel = Channel("tester")
@@ -126,7 +126,7 @@ def test_oauth2_manager_remove_existing_secret(keyring):
     """
     secret = "secret"
     settings = {
-        "auth": "conda-auth-oauth2",
+        "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
     cache = {}
@@ -151,7 +151,7 @@ def test_oauth2_manager_remove_non_existing_secret(keyring):
     """
     secret = "secret"
     settings = {
-        "auth": "conda-auth-oauth2",
+        "auth": OAUTH2_NAME,
         "login_url": "http://localhost",
     }
     cache = {}

--- a/tests/test_condarc.py
+++ b/tests/test_condarc.py
@@ -9,6 +9,7 @@ from conda_auth.condarc import CondaRC, CondaRCError, yaml
 CONDARC_CONTENT = """
 channels:
 - defaults
+channel_settings:
 """
 
 
@@ -41,6 +42,10 @@ def test_update_non_existing_condarc_file(tmp_path):
 def test_update_existing_condarc_file(tmp_path):
     """
     Make sure that the condarc file can be updated even when it does exist
+
+    TODO:
+        It might be nice to expand this test in the future with some more condarc
+        file states via a pytest.parameters decorator.
     """
     channel = "tester"
     username = "username"

--- a/tests/test_condarc.py
+++ b/tests/test_condarc.py
@@ -1,0 +1,109 @@
+from unittest.mock import MagicMock
+
+import pytest
+from ruamel.yaml.error import YAMLError
+
+from conda_auth.condarc import CondaRC, CondaRCError, yaml
+
+
+CONDARC_CONTENT = """
+channels:
+- defaults
+"""
+
+
+def test_update_non_existing_condarc_file(tmp_path):
+    """
+    Make sure that the condarc file can be updated even when it first doesn't exist
+    """
+    channel = "tester"
+    username = "username"
+    auth_type = "http-basic"
+    condarc_path = tmp_path / ".condarc"
+
+    condarc = CondaRC(condarc_path)
+    condarc.update_channel_settings(channel, username, auth_type)
+    condarc.save()
+
+    condarc_dict = yaml.load(condarc_path.read_text())
+
+    assert condarc_dict == {
+        "channel_settings": [
+            {
+                "channel": channel,
+                "username": username,
+                "auth": auth_type,
+            }
+        ]
+    }
+
+
+def test_update_existing_condarc_file(tmp_path):
+    """
+    Make sure that the condarc file can be updated even when it does exist
+    """
+    channel = "tester"
+    username = "username"
+    auth_type = "http-basic"
+    condarc_path = tmp_path / ".condarc"
+    condarc_path.write_text(CONDARC_CONTENT)
+
+    condarc = CondaRC(condarc_path)
+    condarc.update_channel_settings(channel, username, auth_type)
+    condarc.save()
+
+    condarc_dict = yaml.load(condarc_path.read_text())
+
+    assert condarc_dict == {
+        "channel_settings": [
+            {
+                "channel": channel,
+                "username": username,
+                "auth": auth_type,
+            }
+        ],
+        "channels": ["defaults"],
+    }
+
+
+def test_error_while_reading_condarc_file():
+    """
+    Testing to make sure the appropriate error is raised when an OSError occurs
+    """
+    error_message = "Not allowed to read"
+    mock_path = MagicMock()
+    mock_path.open.side_effect = PermissionError(error_message)
+
+    with pytest.raises(CondaRCError, match=error_message):
+        CondaRC(mock_path)
+
+
+def test_error_parsing_yaml(mocker, tmp_path):
+    """
+    Testing to make sure the appropriate error is raised when an YAMLError occurs
+    """
+    error_message = "Parse error"
+    condarc_path = tmp_path / ".condarc"
+    mock_yaml = mocker.patch("conda_auth.condarc.yaml")
+    mock_yaml.load.side_effect = YAMLError(error_message)
+
+    with pytest.raises(CondaRCError, match=error_message):
+        CondaRC(condarc_path)
+
+
+def test_error_saving_condarc(mocker, tmp_path):
+    """
+    Testing to make sure the appropriate error is raised when an OSError occurs on file save
+    """
+    error_message = "Not allowed to write"
+    condarc_path = tmp_path / ".condarc"
+    condarc_path.touch()
+    mock_path = MagicMock()
+    mock_path.open.side_effect = [
+        condarc_path.open("r"),
+        PermissionError(error_message),
+    ]
+
+    with pytest.raises(CondaRCError, match=error_message):
+        condarc = CondaRC(mock_path)
+        condarc.save()

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,3 +1,0 @@
-"""
-Integration tests for testing login
-"""


### PR DESCRIPTION
Fixes: #5

### Additional information

This pull request attempts to make the user experience around logging in and out better. Before these changes, users were expected to manually edit and configure their `.condarc` files before logging in and out. I felt this was a cumbersome step and wanted to see what I could do to fix it.

The solution I came up with was giving the conda-auth plugin the ability to edit the `.condarc` file itself. The information that is written to the `.condarc` is then later used by normal conda commands.

For example, when a user logs in to a HTTP Basic Authentication channel with the following command:

```
conda auth login http://localhost --username user
```

The following information will be automatically saved to their `.condarc` file:

```yaml
channel_settings:
- channel: http://localhost
  auth: http-basic
  username: user
```

The password is then saved using "keyring".

For future authentication types, we will then try our best to infer what type of authentication is being used so that we can avoid having to make users manually specify this.