### PR TITLE
[02/19] Add authenticated channel integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,9 +62,31 @@ jobs:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  integration-tests:
+    name: Integration tests
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.draft == false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          pixi-version: v0.70.2
+          environments: dev-py312
+
+      - name: Install local package
+        run: pixi run -e dev-py312 develop
+
+      - name: Run integration tests
+        run: pixi run -e dev-py312 test-integration
+
   build:
     name: Canary Build
-    needs: [tests]
+    needs: [tests, integration-tests]
     # only build canary build if
     # - prior steps succeeded,
     # - this is the main branch

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -55,10 +55,23 @@ experimenting with it on your computer.
 
 ### Running tests
 
-To run the test for conda-auth, run the following command:
+To run the unit tests for conda-auth, run the following command:
 
 ```
 pixi run --environment dev test
+```
+
+Integration tests run real `conda` subprocesses against local HTTP test servers.
+Run them separately with this command:
+
+```
+pixi run --environment dev test-integration
+```
+
+To run unit and integration tests together, use this command:
+
+```
+pixi run --environment dev test-all
 ```
 
 Or, to generate an HTML coverage report, run with the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,11 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 develop = "pip install -e ."
 
 # Test commands
-test = "pytest --doctest-modules"
-testcov = "pytest --cov=conda_auth --cov-report=xml --doctest-modules"
-testhtml = "pytest --cov=conda_auth --cov-report=html --doctest-modules"
+test = "pytest --doctest-modules -m 'not integration'"
+test-integration = "pytest --doctest-modules -m integration"
+test-all = "pytest --doctest-modules"
+testcov = "pytest --cov=conda_auth --cov-report=xml --doctest-modules -m 'not integration'"
+testhtml = "pytest --cov=conda_auth --cov-report=html --doctest-modules -m 'not integration'"
 
 # Build commands
 build = "rattler-build build --recipe recipe.yaml"
@@ -131,3 +133,8 @@ allowed-unresolved-imports = ["conda_auth._version"]
 
 [tool.ty.src]
 include = ["conda_auth", "tests"]
+
+[tool.pytest.ini_options]
+markers = [
+  "integration: tests that run real conda subprocesses against a local HTTP server",
+]

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for conda-auth."""

--- a/tests/integration/auth_server.py
+++ b/tests/integration/auth_server.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import base64
+import json
+import queue
+import threading
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Literal
+from urllib.parse import unquote, urlsplit
+
+from conda.base.context import context
+
+AuthMode = Literal["none", "basic", "token"]
+
+TEST_PACKAGE_NAME = "conda-auth-test-package"
+TEST_PACKAGE_FILENAME = f"{TEST_PACKAGE_NAME}-1.0.0-0.tar.bz2"
+
+
+@dataclass(frozen=True)
+class RequestRecord:
+    method: str
+    path: str
+    headers: dict[str, str]
+    status_code: int
+
+    @property
+    def authorization(self) -> str | None:
+        return self.headers.get("Authorization")
+
+
+@dataclass
+class AuthenticatedChannelServer:
+    root: Path
+    mode: AuthMode = "none"
+    username: str = "user"
+    password: str = "password"
+    token: str = "token"
+    token_header: str = "Authorization"
+    token_template: str = "Bearer {token}"
+    host: str = "127.0.0.1"
+    records: list[RequestRecord] = field(default_factory=list)
+
+    _server: ThreadingHTTPServer | None = field(default=None, init=False)
+    _thread: threading.Thread | None = field(default=None, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    @classmethod
+    def start(
+        cls,
+        root: Path,
+        *,
+        mode: AuthMode = "none",
+        username: str = "user",
+        password: str = "password",
+        token: str = "token",
+        token_header: str = "Authorization",
+        token_template: str = "Bearer {token}",
+    ) -> AuthenticatedChannelServer:
+        server = cls(
+            root=root,
+            mode=mode,
+            username=username,
+            password=password,
+            token=token,
+            token_header=token_header,
+            token_template=token_template,
+        )
+        server.write_channel()
+        server.start_server()
+        return server
+
+    @property
+    def port(self) -> int:
+        if self._server is None:
+            raise RuntimeError("Server is not running")
+        return self._server.server_port
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def expected_basic_header(self) -> str:
+        secret = f"{self.username}:{self.password}".encode()
+        return f"Basic {base64.b64encode(secret).decode('ascii')}"
+
+    @property
+    def expected_token_value(self) -> str:
+        return self.token_template.format(token=self.token)
+
+    def get_url(self, path: str = "") -> str:
+        path = path.lstrip("/")
+        return f"{self.url}/{path}" if path else self.url
+
+    def write_channel(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        subdirs = ("noarch", context.subdir)
+        for subdir in subdirs:
+            directory = self.root / subdir
+            directory.mkdir(exist_ok=True)
+            repodata = {
+                "info": {"subdir": subdir},
+                "packages": {},
+                "packages.conda": {},
+                "repodata_version": 1,
+            }
+            if subdir == "noarch":
+                repodata["packages"][TEST_PACKAGE_FILENAME] = {
+                    "name": TEST_PACKAGE_NAME,
+                    "version": "1.0.0",
+                    "build": "0",
+                    "build_number": 0,
+                    "subdir": "noarch",
+                    "depends": [],
+                    "md5": "0" * 32,
+                    "sha256": "0" * 64,
+                    "size": 0,
+                    "timestamp": 0,
+                }
+            (directory / "repodata.json").write_text(json.dumps(repodata))
+
+        (self.root / "channeldata.json").write_text(
+            json.dumps(
+                {
+                    "channeldata_version": 1,
+                    "packages": {},
+                    "subdirs": list(subdirs),
+                }
+            )
+        )
+
+    def start_server(self) -> None:
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                owner.handle_request(self, send_body=True)
+
+            def do_HEAD(self) -> None:
+                owner.handle_request(self, send_body=False)
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        class Server(ThreadingHTTPServer):
+            allow_reuse_address = True
+            request_queue_size = 64
+
+        started: queue.Queue[ThreadingHTTPServer | BaseException] = queue.Queue(maxsize=1)
+
+        def run() -> None:
+            try:
+                with Server((self.host, 0), Handler) as httpd:
+                    self._server = httpd
+                    started.put(httpd)
+                    httpd.serve_forever()
+            except BaseException as exc:
+                started.put(exc)
+
+        self._thread = threading.Thread(target=run, daemon=True)
+        self._thread.start()
+        result = started.get(timeout=5)
+        if isinstance(result, BaseException):
+            raise result
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def handle_request(self, handler: BaseHTTPRequestHandler, *, send_body: bool) -> None:
+        status_code = 500
+        try:
+            if status_code := self.auth_failure_status(handler):
+                headers = {}
+                body = b"not authenticated"
+                if status_code == 401:
+                    headers["WWW-Authenticate"] = 'Basic realm="Test"'
+                    body = b"no auth header received"
+                self.send_response(
+                    handler, status_code, body, headers=headers, send_body=send_body
+                )
+                return
+
+            status_code = self.serve_file(handler, send_body=send_body)
+        finally:
+            self.record_request(handler, status_code)
+
+    def auth_failure_status(self, handler: BaseHTTPRequestHandler) -> int | None:
+        if self.mode == "none":
+            return None
+
+        if self.mode == "basic":
+            if handler.headers.get("Authorization") == self.expected_basic_header:
+                return None
+            return 401
+
+        if handler.headers.get(self.token_header) == self.expected_token_value:
+            return None
+        return 403
+
+    def serve_file(self, handler: BaseHTTPRequestHandler, *, send_body: bool) -> int:
+        path = unquote(urlsplit(handler.path).path).lstrip("/")
+        file_path = (self.root / path).resolve()
+
+        try:
+            file_path.relative_to(self.root.resolve())
+        except ValueError:
+            return self.send_response(handler, 404, b"not found", send_body=send_body)
+
+        if not file_path.is_file():
+            return self.send_response(handler, 404, b"not found", send_body=send_body)
+
+        content = file_path.read_bytes()
+        content_type = (
+            "application/json" if file_path.suffix == ".json" else "application/octet-stream"
+        )
+        return self.send_response(
+            handler,
+            200,
+            content,
+            headers={"Content-Type": content_type},
+            send_body=send_body,
+        )
+
+    def send_response(
+        self,
+        handler: BaseHTTPRequestHandler,
+        status_code: int,
+        body: bytes,
+        *,
+        headers: dict[str, str] | None = None,
+        send_body: bool,
+    ) -> int:
+        handler.send_response(status_code)
+        for name, value in (headers or {}).items():
+            handler.send_header(name, value)
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        if send_body:
+            handler.wfile.write(body)
+        return status_code
+
+    def record_request(self, handler: BaseHTTPRequestHandler, status_code: int) -> None:
+        with self._lock:
+            self.records.append(
+                RequestRecord(
+                    method=handler.command,
+                    path=handler.path,
+                    headers={name: value for name, value in handler.headers.items()},
+                    status_code=status_code,
+                )
+            )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from .auth_server import AuthenticatedChannelServer, AuthMode
+
+
+@dataclass
+class CondaRunner:
+    env: dict[str, str]
+    timeout: int = 60
+
+    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        conda = shutil.which("conda")
+        if conda is None:
+            raise RuntimeError("conda executable not found")
+
+        return subprocess.run(
+            [conda, *args],
+            capture_output=True,
+            check=False,
+            env=self.env,
+            text=True,
+            timeout=self.timeout,
+        )
+
+
+@pytest.fixture
+def conda_runner(tmp_path: Path) -> CondaRunner:
+    home = tmp_path / "home"
+    xdg_data = tmp_path / "xdg-data"
+    appdata = tmp_path / "appdata"
+    localappdata = tmp_path / "localappdata"
+    pkgs_dirs = tmp_path / "pkgs"
+    envs_dirs = tmp_path / "envs"
+    for path in (home, xdg_data, appdata, localappdata, pkgs_dirs, envs_dirs):
+        path.mkdir()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "APPDATA": str(appdata),
+            "CONDARC": str(tmp_path / "condarc"),
+            "CONDA_ENVS_DIRS": str(envs_dirs),
+            "CONDA_PKGS_DIRS": str(pkgs_dirs),
+            "HOME": str(home),
+            "LOCALAPPDATA": str(localappdata),
+            "PYTHON_KEYRING_BACKEND": "keyrings.alt.file.PlaintextKeyring",
+            "XDG_DATA_HOME": str(xdg_data),
+        }
+    )
+    return CondaRunner(env=env)
+
+
+@pytest.fixture
+def channel_server(
+    tmp_path: Path,
+) -> Iterator[Callable[..., AuthenticatedChannelServer]]:
+    servers: list[AuthenticatedChannelServer] = []
+
+    def start(
+        *,
+        mode: AuthMode = "none",
+        username: str = "user",
+        password: str = "password",
+        token: str = "token",
+        token_header: str = "Authorization",
+        token_template: str = "Bearer {token}",
+    ) -> AuthenticatedChannelServer:
+        server = AuthenticatedChannelServer.start(
+            tmp_path / f"channel-{len(servers)}",
+            mode=mode,
+            username=username,
+            password=password,
+            token=token,
+            token_header=token_header,
+            token_template=token_template,
+        )
+        servers.append(server)
+        return server
+
+    yield start
+
+    for server in reversed(servers):
+        server.stop()

--- a/tests/integration/test_auth_server.py
+++ b/tests/integration/test_auth_server.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def fetch(url: str, headers: dict[str, str] | None = None) -> tuple[int, bytes, dict[str, str]]:
+    request = Request(url, headers=headers or {})
+    try:
+        with urlopen(request, timeout=5) as response:
+            return response.status, response.read(), dict(response.headers)
+    except HTTPError as exc:
+        return exc.code, exc.read(), dict(exc.headers)
+
+
+def test_basic_auth_server_requires_credentials(channel_server):
+    server = channel_server(mode="basic", username="user", password="pass")
+
+    status, body, headers = fetch(server.get_url("noarch/repodata.json"))
+
+    assert status == 401
+    assert b"no auth header received" in body
+    assert headers["WWW-Authenticate"] == 'Basic realm="Test"'
+
+
+def test_token_auth_server_rejects_wrong_header(channel_server):
+    server = channel_server(
+        mode="token",
+        token="secret-token",
+        token_header="X-Auth",
+        token_template="Token {token}",
+    )
+
+    status, body, _ = fetch(
+        server.get_url("noarch/repodata.json"),
+        headers={"X-Auth": "Token wrong-token"},
+    )
+
+    assert status == 403
+    assert b"not authenticated" in body
+
+
+def test_auth_server_rejects_path_traversal(tmp_path, channel_server):
+    (tmp_path / "outside.txt").write_text("outside")
+    server = channel_server(mode="none")
+
+    status, body, _ = fetch(server.get_url("%2e%2e/outside.txt"))
+
+    assert status == 404
+    assert b"outside" not in body

--- a/tests/integration/test_authenticated_channels.py
+++ b/tests/integration/test_authenticated_channels.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .auth_server import TEST_PACKAGE_NAME
+
+pytestmark = pytest.mark.integration
+
+
+def test_basic_auth_conda_search_uses_stored_credentials(conda_runner, channel_server):
+    server = channel_server(mode="basic", username="user", password="pass")
+
+    login = conda_runner.run(
+        "auth",
+        "login",
+        server.url,
+        "--basic",
+        "--username",
+        "user",
+        "--password",
+        "pass",
+        "--json",
+    )
+    assert login.returncode == 0, login.stderr or login.stdout
+    assert json.loads(login.stdout)["success"] is True
+
+    search = conda_runner.run(
+        "search",
+        "--json",
+        "--override-channels",
+        "-c",
+        server.url,
+        TEST_PACKAGE_NAME,
+    )
+
+    assert search.returncode == 0, search.stderr or search.stdout
+    assert TEST_PACKAGE_NAME in json.loads(search.stdout)
+    assert any(
+        record.path.endswith("repodata.json")
+        and record.authorization == server.expected_basic_header
+        and record.status_code == 200
+        for record in server.records
+    )
+
+
+def test_basic_auth_conda_search_without_credentials_fails(conda_runner, channel_server):
+    server = channel_server(mode="basic", username="user", password="pass")
+
+    search = conda_runner.run(
+        "search",
+        "--json",
+        "--override-channels",
+        "-c",
+        server.url,
+        TEST_PACKAGE_NAME,
+    )
+
+    assert search.returncode != 0
+    assert any(
+        record.path.endswith("repodata.json")
+        and record.authorization is None
+        and record.status_code == 401
+        for record in server.records
+    )
+


### PR DESCRIPTION
## Summary
- Adds a marked integration test server and subprocess coverage for authenticated channel access.

## Review Order
This PR is part of #42. It is currently draft and not ready for review. Please review the stack in order from #46 upward when PRs are marked ready.

## Chain Tracker
- Previous: #46 Use conda-native CLI config and tooling
- Current: #47 Add authenticated channel integration tests
- Next: #50 Load auth credentials lazily
- Status: draft

## Issues
- Closes #4
