### PR TITLE
[03/19] Load auth credentials lazily

### DIFF
--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -98,7 +98,6 @@ def update_channel_settings(
         username,
     )
 
-
 def get_auth_manager(
     auth: str | None = None,
     basic: bool | None = None,
@@ -159,6 +158,7 @@ def logout(channel: Channel):
 
     auth_type, auth_manager = get_auth_manager(**settings)
     auth_manager.remove_secret(channel, settings)
+    auth_manager.cache_clear(channel.canonical_name)
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:

--- a/conda_auth/handlers/base.py
+++ b/conda_auth/handlers/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from fnmatch import fnmatch
 
 import conda.base.context
 from conda.base.context import context as global_context
@@ -26,28 +27,15 @@ class AuthManager(ABC):
         self._context = context or global_context
         self._cache = {} if cache is None else cache
 
-    def hook_action(self, command: str) -> None:
-        """Action callable to be used in the conda pre-command plugin hook"""
-
-        for settings in self._context.channel_settings:
-            if channel := settings.get("channel"):
-                channel = Channel(channel)
-                # Only attempt to authenticate for actively used channels
-                if (
-                    channel.canonical_name in self._context.channels
-                    and settings.get("auth") == self.get_auth_type()
-                ):
-                    self.store(channel, settings)
-
-    def store(self, channel: Channel, settings: Mapping[str, str]) -> str:
+    def store(self, channel: Channel, settings: Mapping[str, str | None]) -> str:
         """
-        Used to retrieve credentials and store them on the ``cache`` property
+        Used to retrieve credentials and store them in the credential store.
 
         This method returns a "username" because this property could have been retrieved
         via user input while calling ``fetch_secret``.
         """
         extra_params = {param: settings.get(param) for param in self.get_config_parameters()}
-        username, secret = self.fetch_secret(channel, extra_params)
+        username, secret = self.fetch_secret(channel, extra_params, use_cache=False)
 
         self.save_credentials(channel, username, secret)
 
@@ -60,12 +48,16 @@ class AuthManager(ABC):
         storage.set_password(self.get_keyring_id(channel), username, secret)
 
     def fetch_secret(
-        self, channel: Channel, settings: Mapping[str, str | None]
+        self,
+        channel: Channel,
+        settings: Mapping[str, str | None],
+        *,
+        use_cache: bool = True,
     ) -> tuple[str, str]:
         """
         Fetch secrets and handle updating cache.
         """
-        if secrets := self._cache.get(channel.canonical_name):
+        if use_cache and (secrets := self._cache.get(channel.canonical_name)):
             return secrets
 
         secrets = self._fetch_secret(channel, settings)
@@ -75,14 +67,46 @@ class AuthManager(ABC):
 
     def get_secret(self, channel_name: str) -> tuple[str | None, str | None]:
         """
-        Get the secret that is currently cached for the channel
+        Get the secret for a channel, using the in-process cache when possible.
         """
-        secrets = self._cache.get(channel_name)
+        channel = Channel(channel_name)
+        secrets = self._cache.get(channel.canonical_name)
 
-        if secrets is None:
+        if secrets is not None:
+            return secrets
+
+        settings = self.get_channel_settings(channel)
+        if settings is None:
             return None, None
 
-        return secrets
+        return self.fetch_secret(channel, settings)
+
+    def get_channel_settings(self, channel: Channel) -> Mapping[str, str | None] | None:
+        """
+        Find the auth settings that apply to a channel.
+        """
+        matched_settings = None
+        for settings in self._context.channel_settings:
+            if settings.get("auth") != self.get_auth_type():
+                continue
+            if configured_channel := settings.get("channel"):
+                if self.channel_matches(configured_channel, channel):
+                    matched_settings = settings
+
+        return matched_settings
+
+    def channel_matches(self, configured_channel: str, channel: Channel) -> bool:
+        """
+        Match configured channel names using conda's canonical channel names.
+        """
+        configured_canonical_name = Channel(configured_channel).canonical_name
+
+        return (
+            configured_channel == channel.canonical_name
+            or configured_canonical_name == channel.canonical_name
+            or fnmatch(channel.canonical_name, configured_channel)
+            or fnmatch(channel.canonical_name, configured_canonical_name)
+        )
 
     def cache_clear(self, channel_name: str | None = None) -> None:
         """

--- a/conda_auth/handlers/basic_auth.py
+++ b/conda_auth/handlers/basic_auth.py
@@ -108,7 +108,7 @@ class BasicAuthHandler(ChannelAuthBase):
         super().__init__(channel_name)
         self.username, self.password = manager.get_secret(channel_name)
 
-        if self.username is None and self.password is None:
+        if self.username is None or self.password is None:
             raise CondaAuthError(
                 f"Unable to find user credentials for requests with channel {channel_name}"
             )

--- a/conda_auth/plugin.py
+++ b/conda_auth/plugin.py
@@ -2,41 +2,8 @@
 A place to register plugin hooks
 """
 
-from conda.cli.conda_argparse import BUILTIN_COMMANDS
 from conda.plugins import hookimpl
-from conda.plugins.types import CondaAuthHandler, CondaPreCommand, CondaSubcommand
-
-from .cli import auth, configure_parser
-from .constants import PLUGIN_NAME
-from .handlers import (
-    HTTP_BASIC_AUTH_NAME,
-    TOKEN_NAME,
-    BasicAuthHandler,
-    TokenAuthHandler,
-    basic_auth_manager,
-    token_auth_manager,
-)
-
-ENV_COMMANDS = {
-    "env_config",
-    "env_create",
-    "env_export",
-    "env_list",
-    "env_remove",
-    "env_update",
-}
-
-BUILD_COMMANDS = {
-    "build",
-    "convert",
-    "debug",
-    "develop",
-    "index",
-    "inspect",
-    "metapackage",
-    "render",
-    "skeleton",
-}
+from conda.plugins.types import CondaAuthHandler, CondaSubcommand
 
 
 @hookimpl
@@ -44,6 +11,8 @@ def conda_subcommands():
     """
     Registers subcommands
     """
+    from .cli import auth, configure_parser
+
     yield CondaSubcommand(
         name="auth",
         action=auth,
@@ -53,26 +22,16 @@ def conda_subcommands():
 
 
 @hookimpl
-def conda_pre_commands():
-    """
-    Registers pre-command hooks
-    """
-    yield CondaPreCommand(
-        name=f"{PLUGIN_NAME}-{HTTP_BASIC_AUTH_NAME}",
-        action=basic_auth_manager.hook_action,
-        run_for=BUILTIN_COMMANDS.union(ENV_COMMANDS, BUILD_COMMANDS),
-    )
-    yield CondaPreCommand(
-        name=f"{PLUGIN_NAME}-{TOKEN_NAME}",
-        action=token_auth_manager.hook_action,
-        run_for=BUILTIN_COMMANDS.union(ENV_COMMANDS, BUILD_COMMANDS),
-    )
-
-
-@hookimpl
 def conda_auth_handlers():
     """
     Registers auth handlers
     """
+    from .handlers import (
+        HTTP_BASIC_AUTH_NAME,
+        TOKEN_NAME,
+        BasicAuthHandler,
+        TokenAuthHandler,
+    )
+
     yield CondaAuthHandler(name=HTTP_BASIC_AUTH_NAME, handler=BasicAuthHandler)
     yield CondaAuthHandler(name=TOKEN_NAME, handler=TokenAuthHandler)

--- a/conda_auth/storage/__init__.py
+++ b/conda_auth/storage/__init__.py
@@ -1,4 +1,5 @@
-# noqa: F401
+from __future__ import annotations
+
 from keyring import get_keyring
 from keyring.errors import NoKeyringError
 
@@ -28,4 +29,29 @@ def get_storage_backend() -> Storage:
     return KeyringStorage()
 
 
-storage = get_storage_backend()
+class LazyStorage(Storage):
+    """
+    Resolve credential storage only when credentials are accessed.
+    """
+
+    def __init__(self) -> None:
+        self._storage: Storage | None = None
+
+    @property
+    def backend(self) -> Storage:
+        if self._storage is None:
+            self._storage = get_storage_backend()
+
+        return self._storage
+
+    def get_password(self, key_id: str, username: str) -> str | None:
+        return self.backend.get_password(key_id, username)
+
+    def set_password(self, key_id: str, username: str, password: str) -> None:
+        return self.backend.set_password(key_id, username, password)
+
+    def delete_password(self, key_id: str, username: str) -> None:
+        return self.backend.delete_password(key_id, username)
+
+
+storage = LazyStorage()

--- a/tests/cli/test_logout.py
+++ b/tests/cli/test_logout.py
@@ -3,10 +3,10 @@ import json
 from conda_auth.cli import SUCCESSFUL_LOGOUT_MESSAGE, auth
 from conda_auth.constants import PLUGIN_NAME
 from conda_auth.exceptions import CondaAuthError
-from conda_auth.handlers.basic_auth import HTTP_BASIC_AUTH_NAME
+from conda_auth.handlers.basic_auth import HTTP_BASIC_AUTH_NAME, manager
 
 
-def test_logout_of_active_session(mocker, runner, keyring):
+def test_logout_of_active_session(mocker, runner, keyring, condarc):
     """
     Logs out of currently active session; this essentially just removes the "keyring" entry
     """
@@ -20,6 +20,7 @@ def test_logout_of_active_session(mocker, runner, keyring):
     mock_context.channel_settings = [
         {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
     ]
+    manager._cache = {channel_name: (username, secret)}
 
     # run command
     result = runner.invoke(auth, ["logout", channel_name])
@@ -27,13 +28,14 @@ def test_logout_of_active_session(mocker, runner, keyring):
     assert SUCCESSFUL_LOGOUT_MESSAGE in result.output
     assert result.exit_code == 0, result.output
 
-    # Make sure the delete password call was invoked correctly
-    assert keyring_mock.delete_password.mock_calls == [
-        mocker.call(f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel_name}", username)
-    ]
+    keyring_mock.delete_password.assert_called_once_with(
+        f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel_name}",
+        username,
+    )
+    assert channel_name not in manager._cache
 
 
-def test_logout_of_active_session_json(mocker, runner, keyring):
+def test_logout_of_active_session_json(mocker, runner, keyring, condarc):
     """
     Logs out of currently active session with JSON output.
     """

--- a/tests/handlers/test_basic_auth.py
+++ b/tests/handlers/test_basic_auth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,6 +20,9 @@ from conda_auth.handlers.basic_auth import (
 @pytest.fixture(autouse=True)
 def clean_up_manager_cache():
     """Makes sure the manager cache gets emptied after each test run"""
+    context = manager._context
+    yield
+    manager._context = context
     manager.cache_clear()
 
 
@@ -76,16 +81,13 @@ def test_basic_auth_manager_with_previous_secret(keyring):
     assert manager._cache == {channel.canonical_name: ("admin", secret)}
 
 
-def test_basic_auth_manager_cache_exists(keyring):
+def test_basic_auth_manager_get_secret_cache_exists(keyring):
     """
     Test to make sure that everything works as expected when a cache entry
     already exists for a credential set.
     """
     secret = "secret"
     username = "admin"
-    settings = {
-        "username": username,
-    }
     channel = Channel("tester")
     manager._cache = {channel.canonical_name: (username, secret)}
 
@@ -93,7 +95,7 @@ def test_basic_auth_manager_cache_exists(keyring):
     keyring_mock, _ = keyring(secret)
 
     # run code under test
-    manager.store(channel, settings)
+    assert manager.get_secret(channel.canonical_name) == (username, secret)
 
     # make assertions
     assert manager._cache == {channel.canonical_name: (username, secret)}
@@ -157,19 +159,21 @@ def test_basic_auth_manager_remove_non_existing_secret(keyring):
         manager.remove_secret(channel, settings)
 
 
-def test_basic_auth_handler(keyring):
+def test_basic_auth_handler(mocker, keyring):
     """
     Test to make sure that we can successfully instantiate and call the ``BasicAuthHandler``
     """
     channel_name = "channel"
     password = "password"
     username = "username"
-    channel = Channel(channel_name)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel, {"username": username, "password": password})
+    context = mocker.MagicMock()
+    context.channel_settings = [
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+    ]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(password)
 
     auth_handler = BasicAuthHandler(channel_name)
 
@@ -179,9 +183,11 @@ def test_basic_auth_handler(keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": _basic_auth_str(username, password)}
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
 
 
-def test_basic_auth_handler_equals_methods(keyring):
+def test_basic_auth_handler_equals_methods(mocker, keyring):
     """
     Test to make sure that we can instantiate multiple ``BasicAuthHandler`` objects and then
     compare the two objects
@@ -194,16 +200,63 @@ def test_basic_auth_handler_equals_methods(keyring):
     channel_two = Channel(channel_name_two)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel_one, {"username": username, "password": password})
-    manager.store(channel_two, {"username": username, "password": password})
+    context = mocker.MagicMock()
+    context.channel_settings = [
+        {
+            "channel": channel_one.canonical_name,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": username,
+        },
+        {
+            "channel": channel_two.canonical_name,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": username,
+        },
+    ]
+    mocker.patch.object(manager, "_context", context)
+    keyring(password)
 
     auth_handler_one = BasicAuthHandler(channel_name_one)
     auth_handler_two = BasicAuthHandler(channel_name_two)
 
     assert (auth_handler_one == auth_handler_two) is True
     assert (auth_handler_one != auth_handler_two) is False
+
+
+def test_basic_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
+    """
+    Test to make sure request-time auth loading only reads keyring once per channel.
+    """
+    channel_name = "channel"
+    username = "username"
+    password = "password"
+
+    context = mocker.MagicMock()
+    context.channel_settings = [
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+    ]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(password)
+
+    BasicAuthHandler(channel_name)
+    BasicAuthHandler(channel_name)
+
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
+
+
+def test_basic_auth_handler_partial_cache_error():
+    """
+    Test to make sure partial cached credentials are rejected.
+    """
+    channel_name = "channel"
+    manager._cache = {channel_name: ("username", None)}
+
+    with pytest.raises(
+        CondaError,
+        match=f"Unable to find user credentials for requests with channel {channel_name}",
+    ):
+        BasicAuthHandler(channel_name)
 
 
 def test_basic_auth_handler_no_credentials_available_error():
@@ -236,10 +289,9 @@ def test_token_auth_manager_get_auth_type():
     assert manager.get_auth_type() == HTTP_BASIC_AUTH_NAME
 
 
-def test_basic_auth_manager_hook_action(keyring):
+def test_basic_auth_manager_get_secret_loads_from_channel_settings(keyring):
     """
-    Test to make sure we can successfully call the ``hook_action`` method for the
-    ``BasicAuthManager``.
+    Test to make sure get_secret loads credentials from matching channel settings.
     """
     channel = "channel"
     username = "username"
@@ -253,7 +305,7 @@ def test_basic_auth_manager_hook_action(keyring):
     ]
     keyring(password)
 
-    token_manager = BasicAuthManager(context)
-    token_manager.hook_action("create")
+    auth_manager = BasicAuthManager(context)
 
-    assert token_manager._cache == {channel: (username, password)}
+    assert auth_manager.get_secret(channel) == (username, password)
+    assert auth_manager._cache == {channel: (username, password)}

--- a/tests/handlers/test_token.py
+++ b/tests/handlers/test_token.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,6 +21,9 @@ from conda_auth.handlers.token import (
 @pytest.fixture(autouse=True)
 def clean_up_manager_cache():
     """Makes sure the manager cache gets emptied after each test run"""
+    context = manager._context
+    yield
+    manager._context = context
     manager.cache_clear()
 
 
@@ -117,7 +122,7 @@ def test_basic_auth_manager_remove_non_existing_secret(keyring):
         manager.remove_secret(channel, settings)
 
 
-def test_token_auth_handler_with_anaconda_dot_org_token(keyring):
+def test_token_auth_handler_with_anaconda_dot_org_token(mocker, keyring):
     """
     Test to make sure that we can successfully instantiate and call the ``TokenAuthHandler``
     using the anaconda.org formatted token
@@ -127,9 +132,10 @@ def test_token_auth_handler_with_anaconda_dot_org_token(keyring):
     channel = Channel(channel_name)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel, {"token": token})
+    context = mocker.MagicMock()
+    context.channel_settings = [{"channel": channel.canonical_name, "auth": TOKEN_NAME}]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(token)
 
     auth_handler = TokenAuthHandler(channel_name)
 
@@ -139,9 +145,11 @@ def test_token_auth_handler_with_anaconda_dot_org_token(keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": f"token {token}"}
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
 
 
-def test_token_auth_handler_with_bearer_token(keyring):
+def test_token_auth_handler_with_bearer_token(mocker, keyring):
     """
     Test to make sure that we can successfully instantiate and call the ``TokenAuthHandler``
     using a bearer token.
@@ -151,9 +159,10 @@ def test_token_auth_handler_with_bearer_token(keyring):
     channel = Channel(channel_name)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel, {"token": token})
+    context = mocker.MagicMock()
+    context.channel_settings = [{"channel": channel.canonical_name, "auth": TOKEN_NAME}]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(token)
 
     auth_handler = TokenAuthHandler(channel_name)
 
@@ -163,6 +172,28 @@ def test_token_auth_handler_with_bearer_token(keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": f"Bearer {token}"}
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
+
+
+def test_token_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
+    """
+    Test to make sure request-time auth loading only reads keyring once per channel.
+    """
+    channel_name = "http://localhost"
+    token = "token"
+    channel = Channel(channel_name)
+
+    context = mocker.MagicMock()
+    context.channel_settings = [{"channel": channel.canonical_name, "auth": TOKEN_NAME}]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(token)
+
+    TokenAuthHandler(channel_name)
+    TokenAuthHandler(channel_name)
+
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
 
 
 def test_token_auth_handler_no_token_available_error():
@@ -195,10 +226,9 @@ def test_token_auth_manager_get_auth_type():
     assert manager.get_auth_type() == TOKEN_NAME
 
 
-def test_token_auth_manager_hook_action(keyring):
+def test_token_auth_manager_get_secret_loads_from_channel_settings(keyring):
     """
-    Test to make sure we can successfully call the ``hook_action`` method for the
-    ``TokenAuthManager``.
+    Test to make sure get_secret loads credentials from matching channel settings.
     """
     channel = "channel"
     token = "token"
@@ -215,6 +245,6 @@ def test_token_auth_manager_hook_action(keyring):
     keyring(token)
 
     token_manager = TokenAuthManager(context)
-    token_manager.hook_action("create")
 
+    assert token_manager.get_secret(channel) == (USERNAME, token)
     assert token_manager._cache == {channel: (USERNAME, token)}

--- a/tests/integration/test_authenticated_channels.py
+++ b/tests/integration/test_authenticated_channels.py
@@ -65,3 +65,50 @@ def test_basic_auth_conda_search_without_credentials_fails(conda_runner, channel
         for record in server.records
     )
 
+
+def test_token_conda_env_create_uses_stored_credentials_after_login(
+    tmp_path, conda_runner, channel_server
+):
+    server = channel_server(mode="token", token="secret-token")
+    environment = tmp_path / "environment.yml"
+    environment.write_text(
+        "\n".join(
+            (
+                "channels:",
+                f"  - {server.url}",
+                "dependencies:",
+                f"  - {TEST_PACKAGE_NAME}",
+                "",
+            )
+        )
+    )
+
+    login = conda_runner.run(
+        "auth",
+        "login",
+        server.url,
+        "--token",
+        "secret-token",
+        "--json",
+    )
+    assert login.returncode == 0, login.stderr or login.stdout
+    assert json.loads(login.stdout)["success"] is True
+
+    create = conda_runner.run(
+        "env",
+        "create",
+        "--file",
+        str(environment),
+        "--name",
+        "conda-auth-token-regression",
+        "--dry-run",
+        "--json",
+    )
+
+    assert create.returncode == 0, create.stderr or create.stdout
+    assert any(
+        record.path.endswith("repodata.json")
+        and record.authorization == "Bearer secret-token"
+        and record.status_code == 200
+        for record in server.records
+    )

--- a/tests/integration/test_plugin_entrypoint.py
+++ b/tests/integration/test_plugin_entrypoint.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ("info", "--json"),
+        ("auth", "--help"),
+    ),
+    ids=("info", "auth-help"),
+)
+def test_conda_entrypoint_does_not_require_storage_backend(conda_runner, args):
+    conda_runner.env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.fail.Keyring"
+
+    result = conda_runner.run(*args)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "Error while loading conda entry point: conda-auth" not in result.stderr
+    if args[0] == "info":
+        assert json.loads(result.stdout)["conda_version"]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,7 +1,10 @@
-from conda.cli.conda_argparse import BUILTIN_COMMANDS
+from __future__ import annotations
+
+import subprocess
+import sys
 
 from conda_auth import plugin
-from conda_auth.constants import PLUGIN_NAME
+from conda_auth.cli import configure_parser
 from conda_auth.handlers import (
     HTTP_BASIC_AUTH_NAME,
     TOKEN_NAME,
@@ -18,22 +21,7 @@ def test_conda_subcommands_hook():
 
     assert objs[0].name == "auth"
     assert objs[0].summary == "Authentication commands for conda"
-    assert objs[0].configure_parser is plugin.configure_parser
-
-
-def test_conda_pre_commands_hook():
-    """
-    Test to make sure that this hook yields the correct objects.
-    """
-    objs = list(plugin.conda_pre_commands())
-
-    run_for = BUILTIN_COMMANDS.union(plugin.ENV_COMMANDS, plugin.BUILD_COMMANDS)
-
-    assert objs[0].name == f"{PLUGIN_NAME}-{HTTP_BASIC_AUTH_NAME}"
-    assert objs[0].run_for == run_for
-
-    assert objs[1].name == f"{PLUGIN_NAME}-{TOKEN_NAME}"
-    assert objs[1].run_for == run_for
+    assert objs[0].configure_parser is configure_parser
 
 
 def test_conda_auth_handlers_hook():
@@ -47,3 +35,29 @@ def test_conda_auth_handlers_hook():
 
     assert objs[1].name == TOKEN_NAME
     assert objs[1].handler == TokenAuthHandler
+
+
+def test_plugin_import_does_not_eagerly_import_runtime_modules():
+    """Importing plugin hooks does not load CLI, storage, or keyring."""
+    code = """
+import sys
+import conda_auth.plugin
+
+eager_modules = {
+    "conda_auth.cli",
+    "conda_auth.storage",
+    "keyring",
+}
+loaded_modules = sorted(eager_modules.intersection(sys.modules))
+if loaded_modules:
+    raise SystemExit(f"eager runtime imports: {loaded_modules}")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Defers credential/keyring work until network commands need auth, avoiding plugin import and non-network command failures.

## Review Order
This PR is part of #42. It is currently draft and not ready for review. Please review the stack in order from #46 upward when PRs are marked ready.

## Chain Tracker
- Previous: #47 Add authenticated channel integration tests
- Current: #50 Load auth credentials lazily
- Next: #51 Keep auth config and credentials consistent
- Status: draft

## Issues
- Closes #39; closes #41
