### PR TITLE
[04/19] Keep auth config and credentials consistent

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,9 +78,6 @@ jobs:
           pixi-version: v0.70.2
           environments: dev-py312
 
-      - name: Install local package
-        run: pixi run -e dev-py312 develop
-
       - name: Run integration tests
         run: pixi run -e dev-py312 test-integration
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,9 +62,31 @@ jobs:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  integration-tests:
+    name: Integration tests
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.draft == false
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          pixi-version: v0.70.2
+          environments: dev-py312
+
+      - name: Install local package
+        run: pixi run -e dev-py312 develop
+
+      - name: Run integration tests
+        run: pixi run -e dev-py312 test-integration
+
   build:
     name: Canary Build
-    needs: [tests]
+    needs: [tests, integration-tests]
     # only build canary build if
     # - prior steps succeeded,
     # - this is the main branch

--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -98,7 +98,6 @@ def update_channel_settings(
         username,
     )
 
-
 def get_auth_manager(
     auth: str | None = None,
     basic: bool | None = None,
@@ -159,6 +158,7 @@ def logout(channel: Channel):
 
     auth_type, auth_manager = get_auth_manager(**settings)
     auth_manager.remove_secret(channel, settings)
+    auth_manager.cache_clear(channel.canonical_name)
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:

--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -98,6 +98,22 @@ def update_channel_settings(
         username,
     )
 
+
+def remove_channel_settings(config: ConfigurationFile, channel: str) -> None:
+    """
+    Remove the user's channel auth settings via conda's configuration file API.
+    """
+    channel_settings = config.content.get("channel_settings", []) or []
+    if not isinstance(channel_settings, list):
+        raise CondaAuthError("Expected 'channel_settings' to be a list")
+
+    config.content["channel_settings"] = [
+        settings
+        for settings in channel_settings
+        if not isinstance(settings, Mapping) or settings.get("channel") != channel
+    ]
+
+
 def get_auth_manager(
     auth: str | None = None,
     basic: bool | None = None,
@@ -130,15 +146,29 @@ def login(channel: Channel, **kwargs):
     Log in to a channel by storing the credentials or tokens associated with it
     """
     auth_type, auth_manager = get_auth_manager(**kwargs)
-    username: str | None = auth_manager.store(channel, kwargs)
+    extra_params = {param: kwargs.get(param) for param in auth_manager.get_config_parameters()}
+    username, secret = auth_manager.fetch_secret(channel, extra_params, use_cache=False)
 
     try:
+        config_username: str | None = username
         if auth_type == TOKEN_NAME:
-            username = None
+            config_username = None
         with ConfigurationFile.from_user_condarc() as config:
-            update_channel_settings(config, channel.canonical_name, auth_type, username)
+            update_channel_settings(config, channel.canonical_name, auth_type, config_username)
     except (CondaError, OSError, yaml.YAMLError) as exc:
+        auth_manager.cache_clear(channel.canonical_name)
         raise CondaAuthError(str(exc))
+
+    try:
+        auth_manager.save_credentials(channel, username, secret)
+    except Exception:
+        auth_manager.cache_clear(channel.canonical_name)
+        try:
+            with ConfigurationFile.from_user_condarc() as config:
+                remove_channel_settings(config, channel.canonical_name)
+        except (CondaError, OSError, yaml.YAMLError):
+            pass
+        raise
 
 
 def logout(channel: Channel):
@@ -157,6 +187,13 @@ def logout(channel: Channel):
         raise CondaAuthError("Unable to find information about logged in session.")
 
     auth_type, auth_manager = get_auth_manager(**settings)
+
+    try:
+        with ConfigurationFile.from_user_condarc() as config:
+            remove_channel_settings(config, channel.canonical_name)
+    except (CondaError, OSError, yaml.YAMLError) as exc:
+        raise CondaAuthError(str(exc))
+
     auth_manager.remove_secret(channel, settings)
     auth_manager.cache_clear(channel.canonical_name)
 

--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -161,13 +161,15 @@ def login(channel: Channel, **kwargs):
 
     try:
         auth_manager.save_credentials(channel, username, secret)
-    except Exception:
+    except Exception as credential_error:
         auth_manager.cache_clear(channel.canonical_name)
         try:
             with ConfigurationFile.from_user_condarc() as config:
                 remove_channel_settings(config, channel.canonical_name)
-        except (CondaError, OSError, yaml.YAMLError):
-            pass
+        except (CondaError, OSError, yaml.YAMLError) as rollback_error:
+            raise CondaAuthError(
+                f"{credential_error}. Failed to roll back channel settings: {rollback_error}"
+            ) from credential_error
         raise
 
 

--- a/conda_auth/handlers/base.py
+++ b/conda_auth/handlers/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from fnmatch import fnmatch
 
 import conda.base.context
 from conda.base.context import context as global_context
@@ -26,28 +27,15 @@ class AuthManager(ABC):
         self._context = context or global_context
         self._cache = {} if cache is None else cache
 
-    def hook_action(self, command: str) -> None:
-        """Action callable to be used in the conda pre-command plugin hook"""
-
-        for settings in self._context.channel_settings:
-            if channel := settings.get("channel"):
-                channel = Channel(channel)
-                # Only attempt to authenticate for actively used channels
-                if (
-                    channel.canonical_name in self._context.channels
-                    and settings.get("auth") == self.get_auth_type()
-                ):
-                    self.store(channel, settings)
-
-    def store(self, channel: Channel, settings: Mapping[str, str]) -> str:
+    def store(self, channel: Channel, settings: Mapping[str, str | None]) -> str:
         """
-        Used to retrieve credentials and store them on the ``cache`` property
+        Used to retrieve credentials and store them in the credential store.
 
         This method returns a "username" because this property could have been retrieved
         via user input while calling ``fetch_secret``.
         """
         extra_params = {param: settings.get(param) for param in self.get_config_parameters()}
-        username, secret = self.fetch_secret(channel, extra_params)
+        username, secret = self.fetch_secret(channel, extra_params, use_cache=False)
 
         self.save_credentials(channel, username, secret)
 
@@ -60,12 +48,16 @@ class AuthManager(ABC):
         storage.set_password(self.get_keyring_id(channel), username, secret)
 
     def fetch_secret(
-        self, channel: Channel, settings: Mapping[str, str | None]
+        self,
+        channel: Channel,
+        settings: Mapping[str, str | None],
+        *,
+        use_cache: bool = True,
     ) -> tuple[str, str]:
         """
         Fetch secrets and handle updating cache.
         """
-        if secrets := self._cache.get(channel.canonical_name):
+        if use_cache and (secrets := self._cache.get(channel.canonical_name)):
             return secrets
 
         secrets = self._fetch_secret(channel, settings)
@@ -75,14 +67,46 @@ class AuthManager(ABC):
 
     def get_secret(self, channel_name: str) -> tuple[str | None, str | None]:
         """
-        Get the secret that is currently cached for the channel
+        Get the secret for a channel, using the in-process cache when possible.
         """
-        secrets = self._cache.get(channel_name)
+        channel = Channel(channel_name)
+        secrets = self._cache.get(channel.canonical_name)
 
-        if secrets is None:
+        if secrets is not None:
+            return secrets
+
+        settings = self.get_channel_settings(channel)
+        if settings is None:
             return None, None
 
-        return secrets
+        return self.fetch_secret(channel, settings)
+
+    def get_channel_settings(self, channel: Channel) -> Mapping[str, str | None] | None:
+        """
+        Find the auth settings that apply to a channel.
+        """
+        matched_settings = None
+        for settings in self._context.channel_settings:
+            if settings.get("auth") != self.get_auth_type():
+                continue
+            if configured_channel := settings.get("channel"):
+                if self.channel_matches(configured_channel, channel):
+                    matched_settings = settings
+
+        return matched_settings
+
+    def channel_matches(self, configured_channel: str, channel: Channel) -> bool:
+        """
+        Match configured channel names using conda's canonical channel names.
+        """
+        configured_canonical_name = Channel(configured_channel).canonical_name
+
+        return (
+            configured_channel == channel.canonical_name
+            or configured_canonical_name == channel.canonical_name
+            or fnmatch(channel.canonical_name, configured_channel)
+            or fnmatch(channel.canonical_name, configured_canonical_name)
+        )
 
     def cache_clear(self, channel_name: str | None = None) -> None:
         """

--- a/conda_auth/handlers/basic_auth.py
+++ b/conda_auth/handlers/basic_auth.py
@@ -108,7 +108,7 @@ class BasicAuthHandler(ChannelAuthBase):
         super().__init__(channel_name)
         self.username, self.password = manager.get_secret(channel_name)
 
-        if self.username is None and self.password is None:
+        if self.username is None or self.password is None:
             raise CondaAuthError(
                 f"Unable to find user credentials for requests with channel {channel_name}"
             )

--- a/conda_auth/plugin.py
+++ b/conda_auth/plugin.py
@@ -2,41 +2,8 @@
 A place to register plugin hooks
 """
 
-from conda.cli.conda_argparse import BUILTIN_COMMANDS
 from conda.plugins import hookimpl
-from conda.plugins.types import CondaAuthHandler, CondaPreCommand, CondaSubcommand
-
-from .cli import auth, configure_parser
-from .constants import PLUGIN_NAME
-from .handlers import (
-    HTTP_BASIC_AUTH_NAME,
-    TOKEN_NAME,
-    BasicAuthHandler,
-    TokenAuthHandler,
-    basic_auth_manager,
-    token_auth_manager,
-)
-
-ENV_COMMANDS = {
-    "env_config",
-    "env_create",
-    "env_export",
-    "env_list",
-    "env_remove",
-    "env_update",
-}
-
-BUILD_COMMANDS = {
-    "build",
-    "convert",
-    "debug",
-    "develop",
-    "index",
-    "inspect",
-    "metapackage",
-    "render",
-    "skeleton",
-}
+from conda.plugins.types import CondaAuthHandler, CondaSubcommand
 
 
 @hookimpl
@@ -44,6 +11,8 @@ def conda_subcommands():
     """
     Registers subcommands
     """
+    from .cli import auth, configure_parser
+
     yield CondaSubcommand(
         name="auth",
         action=auth,
@@ -53,26 +22,16 @@ def conda_subcommands():
 
 
 @hookimpl
-def conda_pre_commands():
-    """
-    Registers pre-command hooks
-    """
-    yield CondaPreCommand(
-        name=f"{PLUGIN_NAME}-{HTTP_BASIC_AUTH_NAME}",
-        action=basic_auth_manager.hook_action,
-        run_for=BUILTIN_COMMANDS.union(ENV_COMMANDS, BUILD_COMMANDS),
-    )
-    yield CondaPreCommand(
-        name=f"{PLUGIN_NAME}-{TOKEN_NAME}",
-        action=token_auth_manager.hook_action,
-        run_for=BUILTIN_COMMANDS.union(ENV_COMMANDS, BUILD_COMMANDS),
-    )
-
-
-@hookimpl
 def conda_auth_handlers():
     """
     Registers auth handlers
     """
+    from .handlers import (
+        HTTP_BASIC_AUTH_NAME,
+        TOKEN_NAME,
+        BasicAuthHandler,
+        TokenAuthHandler,
+    )
+
     yield CondaAuthHandler(name=HTTP_BASIC_AUTH_NAME, handler=BasicAuthHandler)
     yield CondaAuthHandler(name=TOKEN_NAME, handler=TokenAuthHandler)

--- a/conda_auth/storage/__init__.py
+++ b/conda_auth/storage/__init__.py
@@ -1,4 +1,5 @@
-# noqa: F401
+from __future__ import annotations
+
 from keyring import get_keyring
 from keyring.errors import NoKeyringError
 
@@ -28,4 +29,29 @@ def get_storage_backend() -> Storage:
     return KeyringStorage()
 
 
-storage = get_storage_backend()
+class LazyStorage(Storage):
+    """
+    Resolve credential storage only when credentials are accessed.
+    """
+
+    def __init__(self) -> None:
+        self._storage: Storage | None = None
+
+    @property
+    def backend(self) -> Storage:
+        if self._storage is None:
+            self._storage = get_storage_backend()
+
+        return self._storage
+
+    def get_password(self, key_id: str, username: str) -> str | None:
+        return self.backend.get_password(key_id, username)
+
+    def set_password(self, key_id: str, username: str, password: str) -> None:
+        return self.backend.set_password(key_id, username, password)
+
+    def delete_password(self, key_id: str, username: str) -> None:
+        return self.backend.delete_password(key_id, username)
+
+
+storage = LazyStorage()

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -55,10 +55,23 @@ experimenting with it on your computer.
 
 ### Running tests
 
-To run the test for conda-auth, run the following command:
+To run the unit tests for conda-auth, run the following command:
 
 ```
 pixi run --environment dev test
+```
+
+Integration tests run real `conda` subprocesses against local HTTP test servers.
+Run them separately with this command:
+
+```
+pixi run --environment dev test-integration
+```
+
+To run unit and integration tests together, use this command:
+
+```
+pixi run --environment dev test-all
 ```
 
 Or, to generate an HTML coverage report, run with the following command:

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -41,7 +41,6 @@ To set up your development environment, follow these steps:
 1. Set up and activate the development environment with these commands:
    ```
    pixi install
-   pixi run develop
    ```
 2. Next, you will want to start a new shell with the following command:
    ```

--- a/pixi.lock
+++ b/pixi.lock
@@ -8,6 +8,8 @@ environments:
   default:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -148,6 +150,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/unearth-0.18.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -272,6 +275,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py314hd1e8ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -396,6 +400,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py314h9d33bd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -519,9 +524,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py314hc5dbbe4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - pypi: .
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -683,6 +691,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -827,6 +836,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py314hd1e8ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -971,6 +981,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py314h9d33bd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1114,9 +1125,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py314hc5dbbe4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - pypi: .
   dev-py310:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1275,6 +1289,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1414,6 +1429,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py310h3aa7efa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1553,6 +1569,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py310hf151d32_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1691,9 +1708,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py310h1637853_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - pypi: .
   dev-py311:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1852,6 +1872,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -1991,6 +2012,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py311h62e9434_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -2130,6 +2152,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py311h5bb9006_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -2268,9 +2291,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py311hf893f09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - pypi: .
   dev-py312:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2428,6 +2454,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.25.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -2566,6 +2593,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py312h01f6755_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -2704,6 +2732,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py312h37e1c23_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -2841,9 +2870,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py312he5662c2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - pypi: .
   dev-py313:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3006,6 +3038,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.4.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -3152,6 +3185,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py313hcb05632_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -3298,6 +3332,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py313h9734d34_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -3441,9 +3476,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py313h5fd188c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - pypi: .
   dev-py314:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3606,6 +3644,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-21.4.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-4.1.0-pyhcf101f3_0.conda
+      - pypi: .
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -3752,6 +3791,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-cpp-0.8.0-h92383a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.25.0-py314hd1e8ddb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
+      - pypi: .
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -3898,6 +3938,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-cpp-0.8.0-ha1acc90_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.25.0-py314h9d33bd4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
+      - pypi: .
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/_python_abi3_support-1.0-hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
@@ -4042,6 +4083,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-cpp-0.8.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.25.0-py314hc5dbbe4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+      - pypi: .
   docs:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -16882,3 +16924,10 @@ packages:
   purls: []
   size: 388453
   timestamp: 1764777142545
+- pypi: .
+  name: conda-auth
+  requires_dist:
+  - conda>=26.1
+  - keyring
+  - requests
+  requires_python: '>=3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ channels = ["conda-forge"]
 platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 
 [tool.pixi.tasks]
-# Run this first; it will install conda-auth as a local package
-develop = "pip install -e ."
-
 # Test commands
 test = "pytest --doctest-modules -m 'not integration'"
 test-integration = "pytest --doctest-modules -m integration"
@@ -62,6 +59,9 @@ python = ">=3.10"
 conda = ">=26.1"
 keyring = "*"
 requests = "*"
+
+[tool.pixi.pypi-dependencies]
+conda_auth = { path = ".", editable = true }
 
 [tool.pixi.feature.py314.dependencies]
 python = "3.14.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,11 @@ platforms = ["linux-64", "win-64", "osx-64", "osx-arm64"]
 develop = "pip install -e ."
 
 # Test commands
-test = "pytest --doctest-modules"
-testcov = "pytest --cov=conda_auth --cov-report=xml --doctest-modules"
-testhtml = "pytest --cov=conda_auth --cov-report=html --doctest-modules"
+test = "pytest --doctest-modules -m 'not integration'"
+test-integration = "pytest --doctest-modules -m integration"
+test-all = "pytest --doctest-modules"
+testcov = "pytest --cov=conda_auth --cov-report=xml --doctest-modules -m 'not integration'"
+testhtml = "pytest --cov=conda_auth --cov-report=html --doctest-modules -m 'not integration'"
 
 # Build commands
 build = "rattler-build build --recipe recipe.yaml"
@@ -131,3 +133,8 @@ allowed-unresolved-imports = ["conda_auth._version"]
 
 [tool.ty.src]
 include = ["conda_auth", "tests"]
+
+[tool.pytest.ini_options]
+markers = [
+  "integration: tests that run real conda subprocesses against a local HTTP server",
+]

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -157,6 +157,40 @@ def test_login_token_no_options(mocker, runner, keyring, condarc):
     assert SUCCESSFUL_LOGIN_MESSAGE in result.output
 
 
+def test_login_error_when_storing_secret_and_rollback_fails(mocker, runner, keyring, condarc):
+    """
+    Test the case where storing credentials fails AND the subsequent attempt to roll back
+    the condarc settings also fails. The rollback error should be silently swallowed and the
+    original exception from save_credentials should still be raised.
+    """
+    channel_name = "tester"
+
+    keyring_mock, _ = keyring(None)
+    original_error = CondaAuthError("Could not save secret")
+    keyring_mock.set_password.side_effect = original_error
+
+    # The rollback config raises an error when exiting the context manager.
+    rollback_config = mocker.MagicMock()
+    rollback_config.__enter__.return_value = rollback_config
+    rollback_config.__exit__.side_effect = CondaError("Could not roll back settings")
+    rollback_config.content = {}
+
+    # First call (update) returns the normal condarc; second call (rollback) raises on exit.
+    mocker.patch(
+        "conda_auth.cli.ConfigurationFile.from_user_condarc",
+        side_effect=[condarc, rollback_config],
+    )
+
+    result = runner.invoke(
+        auth,
+        ["login", channel_name, "--basic", "--username", "user", "--password", "password"],
+    )
+    exc_type, exception, _ = result.exc_info
+
+    assert exc_type == CondaAuthError
+    assert "Could not save secret" == exception.message
+
+
 @pytest.mark.parametrize(
     "option,message",
     (

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -64,18 +64,17 @@ def test_login_with_invalid_auth_type(runner, keyring, condarc):
     assert "error: Missing option 'basic' / 'token'." in result.output
 
 
-def test_login_succeeds_error_returned_when_updating_condarc(runner, keyring, condarc):
+def test_login_error_when_updating_condarc_does_not_store_secret(runner, keyring, condarc):
     """
     Test the case where the login runs successfully but an error is returned when trying to update
     the condarc file.
     """
     channel_name = "tester"
 
-    # setup mocks
-    keyring(None)
+    # Make condarc persistence fail before the keyring write can happen.
+    keyring_mock, _ = keyring(None)
     condarc.__exit__.side_effect = CondaError("Could not save file")
 
-    # run command
     result = runner.invoke(
         auth,
         ["login", channel_name, "--basic", "--username", "user", "--password", "password"],
@@ -84,6 +83,28 @@ def test_login_succeeds_error_returned_when_updating_condarc(runner, keyring, co
 
     assert exc_type == CondaAuthError
     assert "Could not save file" == exception.message
+    keyring_mock.set_password.assert_not_called()
+
+
+def test_login_error_when_storing_secret_removes_condarc_settings(runner, keyring, condarc):
+    """
+    Test the case where the condarc update succeeds but storing credentials fails.
+    """
+    channel_name = "tester"
+
+    keyring_mock, _ = keyring(None)
+    # If storing the secret fails, the condarc entry must be rolled back.
+    keyring_mock.set_password.side_effect = CondaAuthError("Could not save secret")
+
+    result = runner.invoke(
+        auth,
+        ["login", channel_name, "--basic", "--username", "user", "--password", "password"],
+    )
+    exc_type, exception, _ = result.exc_info
+
+    assert exc_type == CondaAuthError
+    assert "Could not save secret" == exception.message
+    assert condarc.content == {"channel_settings": []}
 
 
 def test_login_token(mocker, runner, keyring, condarc):

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -86,25 +86,42 @@ def test_login_error_when_updating_condarc_does_not_store_secret(runner, keyring
     keyring_mock.set_password.assert_not_called()
 
 
-def test_login_error_when_storing_secret_removes_condarc_settings(runner, keyring, condarc):
-    """
-    Test the case where the condarc update succeeds but storing credentials fails.
-    """
-    channel_name = "tester"
-
+@pytest.mark.parametrize(
+    ("rollback_error", "message"),
+    (
+        (None, "Could not save secret"),
+        (
+            CondaError("Could not roll back settings"),
+            "Could not save secret. Failed to roll back channel settings: "
+            "Could not roll back settings",
+        ),
+    ),
+    ids=("rollback-succeeds", "rollback-fails"),
+)
+def test_login_error_when_storing_secret_reports_rollback(
+    runner,
+    keyring,
+    condarc,
+    rollback_error,
+    message,
+):
+    """Report credential storage errors and any rollback failure."""
     keyring_mock, _ = keyring(None)
-    # If storing the secret fails, the condarc entry must be rolled back.
     keyring_mock.set_password.side_effect = CondaAuthError("Could not save secret")
+    if rollback_error is not None:
+        condarc.__exit__.side_effect = [None, rollback_error]
 
     result = runner.invoke(
         auth,
-        ["login", channel_name, "--basic", "--username", "user", "--password", "password"],
+        ["login", "tester", "--basic", "--username", "user", "--password", "password"],
     )
     exc_type, exception, _ = result.exc_info
 
-    assert exc_type == CondaAuthError
-    assert "Could not save secret" == exception.message
+    assert exc_type is CondaAuthError
+    assert exception.message == message
     assert condarc.content == {"channel_settings": []}
+    if rollback_error is not None:
+        assert exception.__cause__ is keyring_mock.set_password.side_effect
 
 
 def test_login_token(mocker, runner, keyring, condarc):
@@ -155,40 +172,6 @@ def test_login_token_no_options(mocker, runner, keyring, condarc):
 
     assert result.exit_code == 0, result.output
     assert SUCCESSFUL_LOGIN_MESSAGE in result.output
-
-
-def test_login_error_when_storing_secret_and_rollback_fails(mocker, runner, keyring, condarc):
-    """
-    Test the case where storing credentials fails AND the subsequent attempt to roll back
-    the condarc settings also fails. The rollback error should be silently swallowed and the
-    original exception from save_credentials should still be raised.
-    """
-    channel_name = "tester"
-
-    keyring_mock, _ = keyring(None)
-    original_error = CondaAuthError("Could not save secret")
-    keyring_mock.set_password.side_effect = original_error
-
-    # The rollback config raises an error when exiting the context manager.
-    rollback_config = mocker.MagicMock()
-    rollback_config.__enter__.return_value = rollback_config
-    rollback_config.__exit__.side_effect = CondaError("Could not roll back settings")
-    rollback_config.content = {}
-
-    # First call (update) returns the normal condarc; second call (rollback) raises on exit.
-    mocker.patch(
-        "conda_auth.cli.ConfigurationFile.from_user_condarc",
-        side_effect=[condarc, rollback_config],
-    )
-
-    result = runner.invoke(
-        auth,
-        ["login", channel_name, "--basic", "--username", "user", "--password", "password"],
-    )
-    exc_type, exception, _ = result.exc_info
-
-    assert exc_type == CondaAuthError
-    assert "Could not save secret" == exception.message
 
 
 @pytest.mark.parametrize(

--- a/tests/cli/test_logout.py
+++ b/tests/cli/test_logout.py
@@ -1,5 +1,7 @@
 import json
 
+from conda.exceptions import CondaError
+
 from conda_auth.cli import SUCCESSFUL_LOGOUT_MESSAGE, auth
 from conda_auth.constants import PLUGIN_NAME
 from conda_auth.exceptions import CondaAuthError
@@ -21,6 +23,12 @@ def test_logout_of_active_session(mocker, runner, keyring, condarc):
         {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
     ]
     manager._cache = {channel_name: (username, secret)}
+    condarc.content = {
+        "channel_settings": [
+            {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username},
+            {"channel": "other", "auth": "token"},
+        ]
+    }
 
     # run command
     result = runner.invoke(auth, ["logout", channel_name])
@@ -33,6 +41,11 @@ def test_logout_of_active_session(mocker, runner, keyring, condarc):
         username,
     )
     assert channel_name not in manager._cache
+    assert condarc.content == {
+        "channel_settings": [
+            {"channel": "other", "auth": "token"},
+        ]
+    }
 
 
 def test_logout_of_active_session_json(mocker, runner, keyring, condarc):
@@ -49,6 +62,11 @@ def test_logout_of_active_session_json(mocker, runner, keyring, condarc):
     mock_context.channel_settings = [
         {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
     ]
+    condarc.content = {
+        "channel_settings": [
+            {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+        ]
+    }
 
     # run command
     result = runner.invoke(auth, ["logout", channel_name, "--json"])
@@ -58,6 +76,33 @@ def test_logout_of_active_session_json(mocker, runner, keyring, condarc):
         "success": True,
         "message": SUCCESSFUL_LOGOUT_MESSAGE,
     }
+
+
+def test_logout_does_not_remove_secret_when_condarc_update_fails(mocker, runner, keyring, condarc):
+    """
+    Fails before removing the keyring secret if the condarc update fails.
+    """
+    channel_name = "tester"
+    username = "user"
+
+    mock_context = mocker.patch("conda_auth.cli.context")
+    keyring_mock, _ = keyring("password")
+    mock_context.channel_settings = [
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+    ]
+    condarc.content = {
+        "channel_settings": [
+            {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+        ]
+    }
+    condarc.__exit__.side_effect = CondaError("Could not save file")
+
+    result = runner.invoke(auth, ["logout", channel_name])
+    exc_type, exception, _ = result.exc_info
+
+    assert exc_type == CondaAuthError
+    assert "Could not save file" == exception.message
+    keyring_mock.delete_password.assert_not_called()
 
 
 def test_logout_of_non_existing_session(mocker, runner, keyring):

--- a/tests/cli/test_logout.py
+++ b/tests/cli/test_logout.py
@@ -3,10 +3,10 @@ import json
 from conda_auth.cli import SUCCESSFUL_LOGOUT_MESSAGE, auth
 from conda_auth.constants import PLUGIN_NAME
 from conda_auth.exceptions import CondaAuthError
-from conda_auth.handlers.basic_auth import HTTP_BASIC_AUTH_NAME
+from conda_auth.handlers.basic_auth import HTTP_BASIC_AUTH_NAME, manager
 
 
-def test_logout_of_active_session(mocker, runner, keyring):
+def test_logout_of_active_session(mocker, runner, keyring, condarc):
     """
     Logs out of currently active session; this essentially just removes the "keyring" entry
     """
@@ -20,6 +20,7 @@ def test_logout_of_active_session(mocker, runner, keyring):
     mock_context.channel_settings = [
         {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
     ]
+    manager._cache = {channel_name: (username, secret)}
 
     # run command
     result = runner.invoke(auth, ["logout", channel_name])
@@ -27,13 +28,14 @@ def test_logout_of_active_session(mocker, runner, keyring):
     assert SUCCESSFUL_LOGOUT_MESSAGE in result.output
     assert result.exit_code == 0, result.output
 
-    # Make sure the delete password call was invoked correctly
-    assert keyring_mock.delete_password.mock_calls == [
-        mocker.call(f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel_name}", username)
-    ]
+    keyring_mock.delete_password.assert_called_once_with(
+        f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel_name}",
+        username,
+    )
+    assert channel_name not in manager._cache
 
 
-def test_logout_of_active_session_json(mocker, runner, keyring):
+def test_logout_of_active_session_json(mocker, runner, keyring, condarc):
     """
     Logs out of currently active session with JSON output.
     """

--- a/tests/handlers/test_basic_auth.py
+++ b/tests/handlers/test_basic_auth.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,6 +20,9 @@ from conda_auth.handlers.basic_auth import (
 @pytest.fixture(autouse=True)
 def clean_up_manager_cache():
     """Makes sure the manager cache gets emptied after each test run"""
+    context = manager._context
+    yield
+    manager._context = context
     manager.cache_clear()
 
 
@@ -76,16 +81,13 @@ def test_basic_auth_manager_with_previous_secret(keyring):
     assert manager._cache == {channel.canonical_name: ("admin", secret)}
 
 
-def test_basic_auth_manager_cache_exists(keyring):
+def test_basic_auth_manager_get_secret_cache_exists(keyring):
     """
     Test to make sure that everything works as expected when a cache entry
     already exists for a credential set.
     """
     secret = "secret"
     username = "admin"
-    settings = {
-        "username": username,
-    }
     channel = Channel("tester")
     manager._cache = {channel.canonical_name: (username, secret)}
 
@@ -93,7 +95,7 @@ def test_basic_auth_manager_cache_exists(keyring):
     keyring_mock, _ = keyring(secret)
 
     # run code under test
-    manager.store(channel, settings)
+    assert manager.get_secret(channel.canonical_name) == (username, secret)
 
     # make assertions
     assert manager._cache == {channel.canonical_name: (username, secret)}
@@ -157,19 +159,21 @@ def test_basic_auth_manager_remove_non_existing_secret(keyring):
         manager.remove_secret(channel, settings)
 
 
-def test_basic_auth_handler(keyring):
+def test_basic_auth_handler(mocker, keyring):
     """
     Test to make sure that we can successfully instantiate and call the ``BasicAuthHandler``
     """
     channel_name = "channel"
     password = "password"
     username = "username"
-    channel = Channel(channel_name)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel, {"username": username, "password": password})
+    context = mocker.MagicMock()
+    context.channel_settings = [
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+    ]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(password)
 
     auth_handler = BasicAuthHandler(channel_name)
 
@@ -179,9 +183,11 @@ def test_basic_auth_handler(keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": _basic_auth_str(username, password)}
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
 
 
-def test_basic_auth_handler_equals_methods(keyring):
+def test_basic_auth_handler_equals_methods(mocker, keyring):
     """
     Test to make sure that we can instantiate multiple ``BasicAuthHandler`` objects and then
     compare the two objects
@@ -194,16 +200,63 @@ def test_basic_auth_handler_equals_methods(keyring):
     channel_two = Channel(channel_name_two)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel_one, {"username": username, "password": password})
-    manager.store(channel_two, {"username": username, "password": password})
+    context = mocker.MagicMock()
+    context.channel_settings = [
+        {
+            "channel": channel_one.canonical_name,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": username,
+        },
+        {
+            "channel": channel_two.canonical_name,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": username,
+        },
+    ]
+    mocker.patch.object(manager, "_context", context)
+    keyring(password)
 
     auth_handler_one = BasicAuthHandler(channel_name_one)
     auth_handler_two = BasicAuthHandler(channel_name_two)
 
     assert (auth_handler_one == auth_handler_two) is True
     assert (auth_handler_one != auth_handler_two) is False
+
+
+def test_basic_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
+    """
+    Test to make sure request-time auth loading only reads keyring once per channel.
+    """
+    channel_name = "channel"
+    username = "username"
+    password = "password"
+
+    context = mocker.MagicMock()
+    context.channel_settings = [
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+    ]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(password)
+
+    BasicAuthHandler(channel_name)
+    BasicAuthHandler(channel_name)
+
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
+
+
+def test_basic_auth_handler_partial_cache_error():
+    """
+    Test to make sure partial cached credentials are rejected.
+    """
+    channel_name = "channel"
+    manager._cache = {channel_name: ("username", None)}
+
+    with pytest.raises(
+        CondaError,
+        match=f"Unable to find user credentials for requests with channel {channel_name}",
+    ):
+        BasicAuthHandler(channel_name)
 
 
 def test_basic_auth_handler_no_credentials_available_error():
@@ -236,10 +289,9 @@ def test_token_auth_manager_get_auth_type():
     assert manager.get_auth_type() == HTTP_BASIC_AUTH_NAME
 
 
-def test_basic_auth_manager_hook_action(keyring):
+def test_basic_auth_manager_get_secret_loads_from_channel_settings(keyring):
     """
-    Test to make sure we can successfully call the ``hook_action`` method for the
-    ``BasicAuthManager``.
+    Test to make sure get_secret loads credentials from matching channel settings.
     """
     channel = "channel"
     username = "username"
@@ -253,7 +305,7 @@ def test_basic_auth_manager_hook_action(keyring):
     ]
     keyring(password)
 
-    token_manager = BasicAuthManager(context)
-    token_manager.hook_action("create")
+    auth_manager = BasicAuthManager(context)
 
-    assert token_manager._cache == {channel: (username, password)}
+    assert auth_manager.get_secret(channel) == (username, password)
+    assert auth_manager._cache == {channel: (username, password)}

--- a/tests/handlers/test_basic_auth.py
+++ b/tests/handlers/test_basic_auth.py
@@ -15,6 +15,7 @@ from conda_auth.handlers.basic_auth import (
     BasicAuthManager,
     manager,
 )
+from conda_auth.handlers.token import TOKEN_NAME
 
 
 @pytest.fixture(autouse=True)
@@ -72,13 +73,15 @@ def test_basic_auth_manager_with_previous_secret(keyring):
     channel = Channel("tester")
 
     # setup mocks
-    keyring(secret)
+    keyring_mock, _ = keyring(secret)
 
     # run code under test
     manager.store(channel, settings)
+    assert manager.fetch_secret(channel, settings) == ("admin", secret)
 
     # make assertions
     assert manager._cache == {channel.canonical_name: ("admin", secret)}
+    keyring_mock.get_password.assert_called_once()
 
 
 def test_basic_auth_manager_get_secret_cache_exists(keyring):
@@ -301,7 +304,8 @@ def test_basic_auth_manager_get_secret_loads_from_channel_settings(keyring):
     context = MagicMock()
     context.channels = (channel,)
     context.channel_settings = [
-        {"channel": channel, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+        {"channel": channel, "auth": TOKEN_NAME},
+        {"channel": channel, "auth": HTTP_BASIC_AUTH_NAME, "username": username},
     ]
     keyring(password)
 

--- a/tests/handlers/test_token.py
+++ b/tests/handlers/test_token.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,6 +21,9 @@ from conda_auth.handlers.token import (
 @pytest.fixture(autouse=True)
 def clean_up_manager_cache():
     """Makes sure the manager cache gets emptied after each test run"""
+    context = manager._context
+    yield
+    manager._context = context
     manager.cache_clear()
 
 
@@ -117,7 +122,7 @@ def test_basic_auth_manager_remove_non_existing_secret(keyring):
         manager.remove_secret(channel, settings)
 
 
-def test_token_auth_handler_with_anaconda_dot_org_token(keyring):
+def test_token_auth_handler_with_anaconda_dot_org_token(mocker, keyring):
     """
     Test to make sure that we can successfully instantiate and call the ``TokenAuthHandler``
     using the anaconda.org formatted token
@@ -127,9 +132,10 @@ def test_token_auth_handler_with_anaconda_dot_org_token(keyring):
     channel = Channel(channel_name)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel, {"token": token})
+    context = mocker.MagicMock()
+    context.channel_settings = [{"channel": channel.canonical_name, "auth": TOKEN_NAME}]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(token)
 
     auth_handler = TokenAuthHandler(channel_name)
 
@@ -139,9 +145,11 @@ def test_token_auth_handler_with_anaconda_dot_org_token(keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": f"token {token}"}
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
 
 
-def test_token_auth_handler_with_bearer_token(keyring):
+def test_token_auth_handler_with_bearer_token(mocker, keyring):
     """
     Test to make sure that we can successfully instantiate and call the ``TokenAuthHandler``
     using a bearer token.
@@ -151,9 +159,10 @@ def test_token_auth_handler_with_bearer_token(keyring):
     channel = Channel(channel_name)
 
     # setup mocks
-    keyring(None)
-
-    manager.store(channel, {"token": token})
+    context = mocker.MagicMock()
+    context.channel_settings = [{"channel": channel.canonical_name, "auth": TOKEN_NAME}]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(token)
 
     auth_handler = TokenAuthHandler(channel_name)
 
@@ -163,6 +172,28 @@ def test_token_auth_handler_with_bearer_token(keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": f"Bearer {token}"}
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
+
+
+def test_token_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
+    """
+    Test to make sure request-time auth loading only reads keyring once per channel.
+    """
+    channel_name = "http://localhost"
+    token = "token"
+    channel = Channel(channel_name)
+
+    context = mocker.MagicMock()
+    context.channel_settings = [{"channel": channel.canonical_name, "auth": TOKEN_NAME}]
+    mocker.patch.object(manager, "_context", context)
+    keyring_mock, _ = keyring(token)
+
+    TokenAuthHandler(channel_name)
+    TokenAuthHandler(channel_name)
+
+    keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
 
 
 def test_token_auth_handler_no_token_available_error():
@@ -195,10 +226,9 @@ def test_token_auth_manager_get_auth_type():
     assert manager.get_auth_type() == TOKEN_NAME
 
 
-def test_token_auth_manager_hook_action(keyring):
+def test_token_auth_manager_get_secret_loads_from_channel_settings(keyring):
     """
-    Test to make sure we can successfully call the ``hook_action`` method for the
-    ``TokenAuthManager``.
+    Test to make sure get_secret loads credentials from matching channel settings.
     """
     channel = "channel"
     token = "token"
@@ -215,6 +245,6 @@ def test_token_auth_manager_hook_action(keyring):
     keyring(token)
 
     token_manager = TokenAuthManager(context)
-    token_manager.hook_action("create")
 
+    assert token_manager.get_secret(channel) == (USERNAME, token)
     assert token_manager._cache == {channel: (USERNAME, token)}

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for conda-auth."""

--- a/tests/integration/auth_server.py
+++ b/tests/integration/auth_server.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import base64
+import json
+import queue
+import threading
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Literal
+from urllib.parse import unquote, urlsplit
+
+from conda.base.context import context
+
+AuthMode = Literal["none", "basic", "token"]
+
+TEST_PACKAGE_NAME = "conda-auth-test-package"
+TEST_PACKAGE_FILENAME = f"{TEST_PACKAGE_NAME}-1.0.0-0.tar.bz2"
+
+
+@dataclass(frozen=True)
+class RequestRecord:
+    method: str
+    path: str
+    headers: dict[str, str]
+    status_code: int
+
+    @property
+    def authorization(self) -> str | None:
+        return self.headers.get("Authorization")
+
+
+@dataclass
+class AuthenticatedChannelServer:
+    root: Path
+    mode: AuthMode = "none"
+    username: str = "user"
+    password: str = "password"
+    token: str = "token"
+    token_header: str = "Authorization"
+    token_template: str = "Bearer {token}"
+    host: str = "127.0.0.1"
+    records: list[RequestRecord] = field(default_factory=list)
+
+    _server: ThreadingHTTPServer | None = field(default=None, init=False)
+    _thread: threading.Thread | None = field(default=None, init=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    @classmethod
+    def start(
+        cls,
+        root: Path,
+        *,
+        mode: AuthMode = "none",
+        username: str = "user",
+        password: str = "password",
+        token: str = "token",
+        token_header: str = "Authorization",
+        token_template: str = "Bearer {token}",
+    ) -> AuthenticatedChannelServer:
+        server = cls(
+            root=root,
+            mode=mode,
+            username=username,
+            password=password,
+            token=token,
+            token_header=token_header,
+            token_template=token_template,
+        )
+        server.write_channel()
+        server.start_server()
+        return server
+
+    @property
+    def port(self) -> int:
+        if self._server is None:
+            raise RuntimeError("Server is not running")
+        return self._server.server_port
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    @property
+    def expected_basic_header(self) -> str:
+        secret = f"{self.username}:{self.password}".encode()
+        return f"Basic {base64.b64encode(secret).decode('ascii')}"
+
+    @property
+    def expected_token_value(self) -> str:
+        return self.token_template.format(token=self.token)
+
+    def get_url(self, path: str = "") -> str:
+        path = path.lstrip("/")
+        return f"{self.url}/{path}" if path else self.url
+
+    def write_channel(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        subdirs = ("noarch", context.subdir)
+        for subdir in subdirs:
+            directory = self.root / subdir
+            directory.mkdir(exist_ok=True)
+            repodata = {
+                "info": {"subdir": subdir},
+                "packages": {},
+                "packages.conda": {},
+                "repodata_version": 1,
+            }
+            if subdir == "noarch":
+                repodata["packages"][TEST_PACKAGE_FILENAME] = {
+                    "name": TEST_PACKAGE_NAME,
+                    "version": "1.0.0",
+                    "build": "0",
+                    "build_number": 0,
+                    "subdir": "noarch",
+                    "depends": [],
+                    "md5": "0" * 32,
+                    "sha256": "0" * 64,
+                    "size": 0,
+                    "timestamp": 0,
+                }
+            (directory / "repodata.json").write_text(json.dumps(repodata))
+
+        (self.root / "channeldata.json").write_text(
+            json.dumps(
+                {
+                    "channeldata_version": 1,
+                    "packages": {},
+                    "subdirs": list(subdirs),
+                }
+            )
+        )
+
+    def start_server(self) -> None:
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                owner.handle_request(self, send_body=True)
+
+            def do_HEAD(self) -> None:
+                owner.handle_request(self, send_body=False)
+
+            def log_message(self, format: str, *args: object) -> None:
+                return
+
+        class Server(ThreadingHTTPServer):
+            allow_reuse_address = True
+            request_queue_size = 64
+
+        started: queue.Queue[ThreadingHTTPServer | BaseException] = queue.Queue(maxsize=1)
+
+        def run() -> None:
+            try:
+                with Server((self.host, 0), Handler) as httpd:
+                    self._server = httpd
+                    started.put(httpd)
+                    httpd.serve_forever()
+            except BaseException as exc:
+                started.put(exc)
+
+        self._thread = threading.Thread(target=run, daemon=True)
+        self._thread.start()
+        result = started.get(timeout=5)
+        if isinstance(result, BaseException):
+            raise result
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def handle_request(self, handler: BaseHTTPRequestHandler, *, send_body: bool) -> None:
+        status_code = 500
+        try:
+            if status_code := self.auth_failure_status(handler):
+                headers = {}
+                body = b"not authenticated"
+                if status_code == 401:
+                    headers["WWW-Authenticate"] = 'Basic realm="Test"'
+                    body = b"no auth header received"
+                self.send_response(
+                    handler, status_code, body, headers=headers, send_body=send_body
+                )
+                return
+
+            status_code = self.serve_file(handler, send_body=send_body)
+        finally:
+            self.record_request(handler, status_code)
+
+    def auth_failure_status(self, handler: BaseHTTPRequestHandler) -> int | None:
+        if self.mode == "none":
+            return None
+
+        if self.mode == "basic":
+            if handler.headers.get("Authorization") == self.expected_basic_header:
+                return None
+            return 401
+
+        if handler.headers.get(self.token_header) == self.expected_token_value:
+            return None
+        return 403
+
+    def serve_file(self, handler: BaseHTTPRequestHandler, *, send_body: bool) -> int:
+        path = unquote(urlsplit(handler.path).path).lstrip("/")
+        file_path = (self.root / path).resolve()
+
+        try:
+            file_path.relative_to(self.root.resolve())
+        except ValueError:
+            return self.send_response(handler, 404, b"not found", send_body=send_body)
+
+        if not file_path.is_file():
+            return self.send_response(handler, 404, b"not found", send_body=send_body)
+
+        content = file_path.read_bytes()
+        content_type = (
+            "application/json" if file_path.suffix == ".json" else "application/octet-stream"
+        )
+        return self.send_response(
+            handler,
+            200,
+            content,
+            headers={"Content-Type": content_type},
+            send_body=send_body,
+        )
+
+    def send_response(
+        self,
+        handler: BaseHTTPRequestHandler,
+        status_code: int,
+        body: bytes,
+        *,
+        headers: dict[str, str] | None = None,
+        send_body: bool,
+    ) -> int:
+        handler.send_response(status_code)
+        for name, value in (headers or {}).items():
+            handler.send_header(name, value)
+        handler.send_header("Content-Length", str(len(body)))
+        handler.end_headers()
+        if send_body:
+            handler.wfile.write(body)
+        return status_code
+
+    def record_request(self, handler: BaseHTTPRequestHandler, status_code: int) -> None:
+        with self._lock:
+            self.records.append(
+                RequestRecord(
+                    method=handler.command,
+                    path=handler.path,
+                    headers={name: value for name, value in handler.headers.items()},
+                    status_code=status_code,
+                )
+            )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from .auth_server import AuthenticatedChannelServer, AuthMode
+
+
+@dataclass
+class CondaRunner:
+    env: dict[str, str]
+    timeout: int = 60
+
+    def run(self, *args: str) -> subprocess.CompletedProcess[str]:
+        conda = shutil.which("conda")
+        if conda is None:
+            raise RuntimeError("conda executable not found")
+
+        return subprocess.run(
+            [conda, *args],
+            capture_output=True,
+            check=False,
+            env=self.env,
+            text=True,
+            timeout=self.timeout,
+        )
+
+
+@pytest.fixture
+def conda_runner(tmp_path: Path) -> CondaRunner:
+    home = tmp_path / "home"
+    xdg_data = tmp_path / "xdg-data"
+    appdata = tmp_path / "appdata"
+    localappdata = tmp_path / "localappdata"
+    pkgs_dirs = tmp_path / "pkgs"
+    envs_dirs = tmp_path / "envs"
+    for path in (home, xdg_data, appdata, localappdata, pkgs_dirs, envs_dirs):
+        path.mkdir()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "APPDATA": str(appdata),
+            "CONDARC": str(tmp_path / "condarc"),
+            "CONDA_ENVS_DIRS": str(envs_dirs),
+            "CONDA_PKGS_DIRS": str(pkgs_dirs),
+            "HOME": str(home),
+            "LOCALAPPDATA": str(localappdata),
+            "PYTHON_KEYRING_BACKEND": "keyrings.alt.file.PlaintextKeyring",
+            "XDG_DATA_HOME": str(xdg_data),
+        }
+    )
+    return CondaRunner(env=env)
+
+
+@pytest.fixture
+def channel_server(
+    tmp_path: Path,
+) -> Iterator[Callable[..., AuthenticatedChannelServer]]:
+    servers: list[AuthenticatedChannelServer] = []
+
+    def start(
+        *,
+        mode: AuthMode = "none",
+        username: str = "user",
+        password: str = "password",
+        token: str = "token",
+        token_header: str = "Authorization",
+        token_template: str = "Bearer {token}",
+    ) -> AuthenticatedChannelServer:
+        server = AuthenticatedChannelServer.start(
+            tmp_path / f"channel-{len(servers)}",
+            mode=mode,
+            username=username,
+            password=password,
+            token=token,
+            token_header=token_header,
+            token_template=token_template,
+        )
+        servers.append(server)
+        return server
+
+    yield start
+
+    for server in reversed(servers):
+        server.stop()

--- a/tests/integration/test_auth_server.py
+++ b/tests/integration/test_auth_server.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def fetch(url: str, headers: dict[str, str] | None = None) -> tuple[int, bytes, dict[str, str]]:
+    request = Request(url, headers=headers or {})
+    try:
+        with urlopen(request, timeout=5) as response:
+            return response.status, response.read(), dict(response.headers)
+    except HTTPError as exc:
+        return exc.code, exc.read(), dict(exc.headers)
+
+
+def test_basic_auth_server_requires_credentials(channel_server):
+    server = channel_server(mode="basic", username="user", password="pass")
+
+    status, body, headers = fetch(server.get_url("noarch/repodata.json"))
+
+    assert status == 401
+    assert b"no auth header received" in body
+    assert headers["WWW-Authenticate"] == 'Basic realm="Test"'
+
+
+def test_token_auth_server_rejects_wrong_header(channel_server):
+    server = channel_server(
+        mode="token",
+        token="secret-token",
+        token_header="X-Auth",
+        token_template="Token {token}",
+    )
+
+    status, body, _ = fetch(
+        server.get_url("noarch/repodata.json"),
+        headers={"X-Auth": "Token wrong-token"},
+    )
+
+    assert status == 403
+    assert b"not authenticated" in body
+
+
+def test_auth_server_rejects_path_traversal(tmp_path, channel_server):
+    (tmp_path / "outside.txt").write_text("outside")
+    server = channel_server(mode="none")
+
+    status, body, _ = fetch(server.get_url("%2e%2e/outside.txt"))
+
+    assert status == 404
+    assert b"outside" not in body

--- a/tests/integration/test_authenticated_channels.py
+++ b/tests/integration/test_authenticated_channels.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .auth_server import TEST_PACKAGE_NAME
+
+pytestmark = pytest.mark.integration
+
+
+def test_basic_auth_conda_search_uses_stored_credentials(conda_runner, channel_server):
+    server = channel_server(mode="basic", username="user", password="pass")
+
+    login = conda_runner.run(
+        "auth",
+        "login",
+        server.url,
+        "--basic",
+        "--username",
+        "user",
+        "--password",
+        "pass",
+        "--json",
+    )
+    assert login.returncode == 0, login.stderr or login.stdout
+    assert json.loads(login.stdout)["success"] is True
+
+    search = conda_runner.run(
+        "search",
+        "--json",
+        "--override-channels",
+        "-c",
+        server.url,
+        TEST_PACKAGE_NAME,
+    )
+
+    assert search.returncode == 0, search.stderr or search.stdout
+    assert TEST_PACKAGE_NAME in json.loads(search.stdout)
+    assert any(
+        record.path.endswith("repodata.json")
+        and record.authorization == server.expected_basic_header
+        and record.status_code == 200
+        for record in server.records
+    )
+
+
+def test_basic_auth_conda_search_without_credentials_fails(conda_runner, channel_server):
+    server = channel_server(mode="basic", username="user", password="pass")
+
+    search = conda_runner.run(
+        "search",
+        "--json",
+        "--override-channels",
+        "-c",
+        server.url,
+        TEST_PACKAGE_NAME,
+    )
+
+    assert search.returncode != 0
+    assert any(
+        record.path.endswith("repodata.json")
+        and record.authorization is None
+        and record.status_code == 401
+        for record in server.records
+    )
+

--- a/tests/integration/test_authenticated_channels.py
+++ b/tests/integration/test_authenticated_channels.py
@@ -65,3 +65,50 @@ def test_basic_auth_conda_search_without_credentials_fails(conda_runner, channel
         for record in server.records
     )
 
+
+def test_token_conda_env_create_uses_stored_credentials_after_login(
+    tmp_path, conda_runner, channel_server
+):
+    server = channel_server(mode="token", token="secret-token")
+    environment = tmp_path / "environment.yml"
+    environment.write_text(
+        "\n".join(
+            (
+                "channels:",
+                f"  - {server.url}",
+                "dependencies:",
+                f"  - {TEST_PACKAGE_NAME}",
+                "",
+            )
+        )
+    )
+
+    login = conda_runner.run(
+        "auth",
+        "login",
+        server.url,
+        "--token",
+        "secret-token",
+        "--json",
+    )
+    assert login.returncode == 0, login.stderr or login.stdout
+    assert json.loads(login.stdout)["success"] is True
+
+    create = conda_runner.run(
+        "env",
+        "create",
+        "--file",
+        str(environment),
+        "--name",
+        "conda-auth-token-regression",
+        "--dry-run",
+        "--json",
+    )
+
+    assert create.returncode == 0, create.stderr or create.stdout
+    assert any(
+        record.path.endswith("repodata.json")
+        and record.authorization == "Bearer secret-token"
+        and record.status_code == 200
+        for record in server.records
+    )

--- a/tests/integration/test_plugin_entrypoint.py
+++ b/tests/integration/test_plugin_entrypoint.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.parametrize(
+    "args",
+    (
+        ("info", "--json"),
+        ("auth", "--help"),
+    ),
+    ids=("info", "auth-help"),
+)
+def test_conda_entrypoint_does_not_require_storage_backend(conda_runner, args):
+    conda_runner.env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.fail.Keyring"
+
+    result = conda_runner.run(*args)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "Error while loading conda entry point: conda-auth" not in result.stderr
+    if args[0] == "info":
+        assert json.loads(result.stdout)["conda_version"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,11 @@ import pytest
 from conda.cli.condarc import ConfigurationFile
 from conda.common.serialize import yaml
 
-from conda_auth.cli import get_updated_channel_settings, update_channel_settings
+from conda_auth.cli import (
+    get_updated_channel_settings,
+    remove_channel_settings,
+    update_channel_settings,
+)
 from conda_auth.exceptions import CondaAuthError
 
 CONDARC_CONTENT = """
@@ -76,3 +80,29 @@ def test_update_channel_settings_requires_list():
 
     with pytest.raises(CondaAuthError, match="Expected 'channel_settings' to be a list"):
         update_channel_settings(config, "tester", "token")
+
+
+def test_remove_channel_settings():
+    config = ConfigurationFile(
+        content={
+            "channel_settings": [
+                {"channel": "tester", "auth": "token"},
+                {"channel": "other", "auth": "token"},
+            ]
+        }
+    )
+
+    remove_channel_settings(config, "tester")
+
+    assert config.content == {
+        "channel_settings": [
+            {"channel": "other", "auth": "token"},
+        ]
+    }
+
+
+def test_remove_channel_settings_requires_list():
+    config = ConfigurationFile(content={"channel_settings": "tester"})
+
+    with pytest.raises(CondaAuthError, match="Expected 'channel_settings' to be a list"):
+        remove_channel_settings(config, "tester")

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,7 +1,10 @@
-from conda.cli.conda_argparse import BUILTIN_COMMANDS
+from __future__ import annotations
+
+import subprocess
+import sys
 
 from conda_auth import plugin
-from conda_auth.constants import PLUGIN_NAME
+from conda_auth.cli import configure_parser
 from conda_auth.handlers import (
     HTTP_BASIC_AUTH_NAME,
     TOKEN_NAME,
@@ -18,22 +21,7 @@ def test_conda_subcommands_hook():
 
     assert objs[0].name == "auth"
     assert objs[0].summary == "Authentication commands for conda"
-    assert objs[0].configure_parser is plugin.configure_parser
-
-
-def test_conda_pre_commands_hook():
-    """
-    Test to make sure that this hook yields the correct objects.
-    """
-    objs = list(plugin.conda_pre_commands())
-
-    run_for = BUILTIN_COMMANDS.union(plugin.ENV_COMMANDS, plugin.BUILD_COMMANDS)
-
-    assert objs[0].name == f"{PLUGIN_NAME}-{HTTP_BASIC_AUTH_NAME}"
-    assert objs[0].run_for == run_for
-
-    assert objs[1].name == f"{PLUGIN_NAME}-{TOKEN_NAME}"
-    assert objs[1].run_for == run_for
+    assert objs[0].configure_parser is configure_parser
 
 
 def test_conda_auth_handlers_hook():
@@ -47,3 +35,29 @@ def test_conda_auth_handlers_hook():
 
     assert objs[1].name == TOKEN_NAME
     assert objs[1].handler == TokenAuthHandler
+
+
+def test_plugin_import_does_not_eagerly_import_runtime_modules():
+    """Importing plugin hooks does not load CLI, storage, or keyring."""
+    code = """
+import sys
+import conda_auth.plugin
+
+eager_modules = {
+    "conda_auth.cli",
+    "conda_auth.storage",
+    "keyring",
+}
+loaded_modules = sorted(eager_modules.intersection(sys.modules))
+if loaded_modules:
+    raise SystemExit(f"eager runtime imports: {loaded_modules}")
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary
- Keeps auth configuration and stored credentials consistent when login/logout fails or rolls back.

## Review Order
This PR is part of #42. It is currently draft and not ready for review. Please review the stack in order from #46 upward when PRs are marked ready.

## Chain Tracker
- Previous: #50 Load auth credentials lazily
- Current: #51 Keep auth config and credentials consistent
- Next: #55 Format CLI validation errors through conda
- Status: draft

## Issues
- Closes #45
