### PR TITLE
[06/19] Preserve non-auth channel settings

### DIFF
--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -33,6 +33,15 @@ SUCCESSFUL_LOGOUT_MESSAGE = "Successfully removed credentials"
 
 PROMPT_VALUE = object()
 
+AUTH_CHANNEL_SETTING_KEYS = frozenset(
+    (
+        "auth",
+        "username",
+        "password",
+        "token",
+    )
+)
+
 
 def prompt_text(prompt: str) -> str:
     """
@@ -65,17 +74,37 @@ def get_updated_channel_settings(
     username: str | None = None,
 ) -> list:
     """
-    Replace the auth settings for a single channel.
+    Replace the auth-owned settings for a single channel.
     """
-    updated_settings = {"channel": channel, "auth": auth_type}
+    updated_settings: dict[str, object] = {"channel": channel}
+    last_channel_index = next(
+        (
+            index
+            for index, settings in reversed(list(enumerate(channel_settings)))
+            if isinstance(settings, Mapping) and settings.get("channel") == channel
+        ),
+        None,
+    )
+    if last_channel_index is not None:
+        updated_settings.update(
+            {
+                key: value
+                for key, value in channel_settings[last_channel_index].items()
+                if key not in AUTH_CHANNEL_SETTING_KEYS
+            }
+        )
+
+    updated_settings["auth"] = auth_type
     if username is not None:
         updated_settings["username"] = username
 
+    if last_channel_index is None:
+        return [*channel_settings, updated_settings]
+
     return [
-        settings
-        for settings in channel_settings
-        if not isinstance(settings, Mapping) or settings.get("channel") != channel
-    ] + [updated_settings]
+        updated_settings if index == last_channel_index else settings
+        for index, settings in enumerate(channel_settings)
+    ]
 
 
 def update_channel_settings(
@@ -99,7 +128,7 @@ def update_channel_settings(
     )
 
 
-def remove_channel_settings(config: ConfigurationFile, channel: str) -> None:
+def remove_channel_settings(config: ConfigurationFile, channel: str) -> bool:
     """
     Remove the user's channel auth settings via conda's configuration file API.
     """
@@ -107,11 +136,24 @@ def remove_channel_settings(config: ConfigurationFile, channel: str) -> None:
     if not isinstance(channel_settings, list):
         raise CondaAuthError("Expected 'channel_settings' to be a list")
 
-    config.content["channel_settings"] = [
-        settings
-        for settings in channel_settings
-        if not isinstance(settings, Mapping) or settings.get("channel") != channel
-    ]
+    removed_auth_settings = False
+    updated_channel_settings = []
+    for settings in channel_settings:
+        if not isinstance(settings, Mapping) or settings.get("channel") != channel:
+            updated_channel_settings.append(settings)
+            continue
+
+        removed_auth_settings = removed_auth_settings or any(
+            key in settings for key in AUTH_CHANNEL_SETTING_KEYS
+        )
+        updated_settings = {
+            key: value for key, value in settings.items() if key not in AUTH_CHANNEL_SETTING_KEYS
+        }
+        if updated_settings != {"channel": channel}:
+            updated_channel_settings.append(updated_settings)
+
+    config.content["channel_settings"] = updated_channel_settings
+    return removed_auth_settings
 
 
 def get_auth_manager(
@@ -192,7 +234,12 @@ def logout(channel: Channel):
 
     try:
         with ConfigurationFile.from_user_condarc() as config:
-            remove_channel_settings(config, channel.canonical_name)
+            removed_auth_settings = remove_channel_settings(config, channel.canonical_name)
+            if not removed_auth_settings:
+                raise CondaAuthError(
+                    "Unable to remove authentication settings from the user condarc. "
+                    "Remove them from the configuration source where they are defined."
+                )
     except (CondaError, OSError, yaml.YAMLError) as exc:
         raise CondaAuthError(str(exc))
 

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -140,6 +140,27 @@ def test_login_error_when_storing_secret_reports_rollback(
         assert exception.__cause__ is keyring_mock.set_password.side_effect
 
 
+def test_login_error_when_storing_secret_preserves_non_auth_settings(runner, keyring, condarc):
+    channel_name = "tester"
+
+    # Rolling back auth settings must not remove other channel-scoped conda settings.
+    keyring_mock, _ = keyring(None)
+    keyring_mock.set_password.side_effect = CondaAuthError("Could not save secret")
+    condarc.content = {"channel_settings": [{"channel": channel_name, "ssl_verify": False}]}
+
+    result = runner.invoke(
+        auth,
+        ["login", channel_name, "--basic", "--username", "user", "--password", "password"],
+    )
+    exc_type, exception, _ = result.exc_info
+
+    assert exc_type == CondaAuthError
+    assert "Could not save secret" == exception.message
+    assert condarc.content == {
+        "channel_settings": [{"channel": channel_name, "ssl_verify": False}]
+    }
+
+
 def test_login_token(mocker, runner, keyring, condarc):
     """
     Test successful login with token

--- a/tests/cli/test_logout.py
+++ b/tests/cli/test_logout.py
@@ -25,7 +25,12 @@ def test_logout_of_active_session(mocker, runner, keyring, condarc):
     manager._cache = {channel_name: (username, secret)}
     condarc.content = {
         "channel_settings": [
-            {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username},
+            {
+                "channel": channel_name,
+                "auth": HTTP_BASIC_AUTH_NAME,
+                "username": username,
+                "ssl_verify": False,
+            },
             {"channel": "other", "auth": "token"},
         ]
     }
@@ -43,6 +48,7 @@ def test_logout_of_active_session(mocker, runner, keyring, condarc):
     assert channel_name not in manager._cache
     assert condarc.content == {
         "channel_settings": [
+            {"channel": channel_name, "ssl_verify": False},
             {"channel": "other", "auth": "token"},
         ]
     }
@@ -103,6 +109,31 @@ def test_logout_does_not_remove_secret_when_condarc_update_fails(mocker, runner,
     assert exc_type == CondaAuthError
     assert "Could not save file" == exception.message
     keyring_mock.delete_password.assert_not_called()
+
+
+def test_logout_refuses_when_auth_settings_are_not_in_user_condarc(
+    mocker, runner, keyring, condarc
+):
+    channel_name = "tester"
+    username = "user"
+
+    # Active auth can come from system or environment config, not just the user condarc.
+    mock_context = mocker.patch("conda_auth.cli.context")
+    keyring_mock, _ = keyring("password")
+    mock_context.channel_settings = [
+        {"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}
+    ]
+    condarc.content = {"channel_settings": [{"channel": channel_name, "ssl_verify": False}]}
+
+    result = runner.invoke(auth, ["logout", channel_name])
+    exc_type, exception, _ = result.exc_info
+
+    assert exc_type == CondaAuthError
+    assert "configuration source where they are defined" in exception.message
+    keyring_mock.delete_password.assert_not_called()
+    assert condarc.content == {
+        "channel_settings": [{"channel": channel_name, "ssl_verify": False}]
+    }
 
 
 def test_logout_of_non_existing_session(mocker, runner, keyring):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,9 +16,9 @@ channel_settings:
 """
 
 
-def test_get_updated_channel_settings_replaces_existing_channel():
+def test_get_updated_channel_settings_preserves_existing_channel_settings():
     channel_settings = [
-        {"channel": "tester", "auth": "token"},
+        {"channel": "tester", "auth": "token", "ssl_verify": False},
         {"channel": "other", "auth": "token"},
     ]
 
@@ -28,8 +28,30 @@ def test_get_updated_channel_settings_replaces_existing_channel():
         "http-basic",
         "username",
     ) == [
+        {
+            "channel": "tester",
+            "ssl_verify": False,
+            "auth": "http-basic",
+            "username": "username",
+        },
         {"channel": "other", "auth": "token"},
-        {"channel": "tester", "auth": "http-basic", "username": "username"},
+    ]
+
+
+def test_get_updated_channel_settings_updates_last_exact_channel():
+    channel_settings = [
+        {"channel": "tester", "auth": "token", "description": "older"},
+        {"channel": "tester", "ssl_verify": False},
+    ]
+
+    assert get_updated_channel_settings(channel_settings, "tester", "http-basic", "username") == [
+        {"channel": "tester", "auth": "token", "description": "older"},
+        {
+            "channel": "tester",
+            "ssl_verify": False,
+            "auth": "http-basic",
+            "username": "username",
+        },
     ]
 
 
@@ -92,7 +114,7 @@ def test_remove_channel_settings():
         }
     )
 
-    remove_channel_settings(config, "tester")
+    assert remove_channel_settings(config, "tester") is True
 
     assert config.content == {
         "channel_settings": [
@@ -101,8 +123,51 @@ def test_remove_channel_settings():
     }
 
 
-def test_remove_channel_settings_requires_list():
+def test_remove_channel_settings_preserves_non_auth_settings():
+    config = ConfigurationFile(
+        content={
+            "channel_settings": [
+                {
+                    "channel": "tester",
+                    "auth": "token",
+                    "ssl_verify": False,
+                },
+                {"channel": "other", "auth": "token"},
+            ]
+        }
+    )
+
+    assert remove_channel_settings(config, "tester") is True
+
+    assert config.content == {
+        "channel_settings": [
+            {"channel": "tester", "ssl_verify": False},
+            {"channel": "other", "auth": "token"},
+        ]
+    }
+
+
+def test_remove_channel_settings_reports_when_no_auth_settings_removed():
+    config = ConfigurationFile(
+        content={"channel_settings": [{"channel": "tester", "ssl_verify": False}]}
+    )
+
+    assert remove_channel_settings(config, "tester") is False
+
+    assert config.content == {"channel_settings": [{"channel": "tester", "ssl_verify": False}]}
+
+
+@pytest.mark.parametrize(
+    ("settings_func", "args"),
+    (
+        (update_channel_settings, ("tester", "token")),
+        (remove_channel_settings, ("tester",)),
+    ),
+    ids=("update", "remove"),
+)
+def test_channel_settings_helpers_require_list(settings_func, args):
+    # Both helpers reject malformed channel_settings before mutating content.
     config = ConfigurationFile(content={"channel_settings": "tester"})
 
     with pytest.raises(CondaAuthError, match="Expected 'channel_settings' to be a list"):
-        remove_channel_settings(config, "tester")
+        settings_func(config, *args)


### PR DESCRIPTION
## Summary
- Keeps unrelated channel_settings keys intact when login, logout, and rollback update auth metadata.

## Review Order
This PR is part of #42 and is ready for review after #55. Its base is #55, so review these two PRs in order.

## Chain Tracker
- Previous: #55 Format CLI validation errors through conda
- Current: #56 Preserve non-auth channel settings
- Next: #57 Match channel auth settings like conda
- Status: ready for review

## Issues
- Refs #45
