### PR TITLE
[07/19] Match channel auth settings like conda

### DIFF
--- a/conda_auth/handlers/base.py
+++ b/conda_auth/handlers/base.py
@@ -6,6 +6,7 @@ from fnmatch import fnmatch
 
 import conda.base.context
 from conda.base.context import context as global_context
+from conda.common.url import urlparse as conda_urlparse
 from conda.models.channel import Channel
 
 from ..storage import storage
@@ -90,6 +91,8 @@ class AuthManager(ABC):
             if settings.get("auth") != self.get_auth_type():
                 continue
             if configured_channel := settings.get("channel"):
+                if not isinstance(configured_channel, str):
+                    continue
                 if self.channel_matches(configured_channel, channel):
                     matched_settings = settings
 
@@ -97,16 +100,19 @@ class AuthManager(ABC):
 
     def channel_matches(self, configured_channel: str, channel: Channel) -> bool:
         """
-        Match configured channel names using conda's canonical channel names.
+        Match configured channel names the same way conda selects auth handlers.
         """
-        configured_canonical_name = Channel(configured_channel).canonical_name
+        if configured_channel == channel.canonical_name:
+            return True
 
-        return (
-            configured_channel == channel.canonical_name
-            or configured_canonical_name == channel.canonical_name
-            or fnmatch(channel.canonical_name, configured_channel)
-            or fnmatch(channel.canonical_name, configured_canonical_name)
-        )
+        parsed_channel = conda_urlparse(channel.base_url)
+        parsed_setting = conda_urlparse(configured_channel)
+        if parsed_setting.scheme != parsed_channel.scheme:
+            return False
+
+        channel_url = parsed_channel.netloc + parsed_channel.path
+        pattern = parsed_setting.netloc + parsed_setting.path
+        return fnmatch(channel_url, pattern)
 
     def cache_clear(self, channel_name: str | None = None) -> None:
         """

--- a/tests/handlers/test_basic_auth.py
+++ b/tests/handlers/test_basic_auth.py
@@ -313,3 +313,56 @@ def test_basic_auth_manager_get_secret_loads_from_channel_settings(keyring):
 
     assert auth_manager.get_secret(channel) == (username, password)
     assert auth_manager._cache == {channel: (username, password)}
+
+
+@pytest.mark.parametrize(
+    ("configured_channel", "channel_name", "expected"),
+    (
+        ("conda-forge", "conda-forge", True),
+        ("https://repo.example.com/private", "https://repo.example.com/private", True),
+        ("https://repo.example.com/*", "https://repo.example.com/private", True),
+        ("http://repo.example.com/*", "https://repo.example.com/private", False),
+        ("*", "https://repo.example.com/private", False),
+    ),
+    ids=("named-exact", "url-exact", "url-pattern", "scheme-mismatch", "schemeless-glob"),
+)
+def test_basic_auth_manager_channel_matches_like_conda(configured_channel, channel_name, expected):
+    """Channel matching follows conda's auth-handler lookup rules."""
+    auth_manager = BasicAuthManager()
+
+    assert auth_manager.channel_matches(configured_channel, Channel(channel_name)) is expected
+
+
+def test_basic_auth_manager_get_channel_settings_uses_last_matching_setting():
+    """Matching settings use conda's last-match-wins behavior."""
+    channel_name = "https://repo.example.com/private"
+    context = MagicMock()
+    context.channel_settings = [
+        {
+            "channel": channel_name,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "exact",
+        },
+        {
+            "channel": 1,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "invalid",
+        },
+        {
+            "channel": "https://repo.example.com/*",
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "wildcard",
+        },
+        {
+            "channel": "*",
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "schemeless",
+        },
+    ]
+    auth_manager = BasicAuthManager(context)
+
+    assert auth_manager.get_channel_settings(Channel(channel_name)) == {
+        "channel": "https://repo.example.com/*",
+        "auth": HTTP_BASIC_AUTH_NAME,
+        "username": "wildcard",
+    }


### PR DESCRIPTION
## Summary
- Aligns auth channel selection with conda-style exact, wildcard, and last-match-wins channel settings behavior.

## Review Order
This PR is part of #42 and is ready for review after #71 landed the reviewed #56 patch in `main`. Review #57 before #58.

## Chain Tracker
- Previous: #71 Land the reviewed #56 patch in `main`
- Current: #57 Match channel auth settings like conda
- Next: #58 Harden auth transport handling
- Status: ready for review

## Issues
- Refs #53