### PR TITLE
[08/19] Harden auth transport handling

### DIFF
--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -12,6 +12,7 @@ from conda.common.serialize import json, yaml
 from conda.exceptions import CondaError
 from conda.models.channel import Channel
 
+from .constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
 from .exceptions import CondaAuthError
 from .handlers import (
     HTTP_BASIC_AUTH_NAME,
@@ -19,6 +20,10 @@ from .handlers import (
     AuthManager,
     basic_auth_manager,
     token_auth_manager,
+)
+from .handlers.base import (
+    allows_plaintext_http,
+    validate_secure_channel,
 )
 
 # Constants
@@ -39,6 +44,7 @@ AUTH_CHANNEL_SETTING_KEYS = frozenset(
         "username",
         "password",
         "token",
+        AUTH_ALLOW_PLAINTEXT_HTTP_PARAM,
     )
 )
 
@@ -72,6 +78,8 @@ def get_updated_channel_settings(
     channel: str,
     auth_type: str,
     username: str | None = None,
+    *,
+    allow_plaintext_http: bool = False,
 ) -> list:
     """
     Replace the auth-owned settings for a single channel.
@@ -97,6 +105,8 @@ def get_updated_channel_settings(
     updated_settings["auth"] = auth_type
     if username is not None:
         updated_settings["username"] = username
+    if allow_plaintext_http:
+        updated_settings[AUTH_ALLOW_PLAINTEXT_HTTP_PARAM] = True
 
     if last_channel_index is None:
         return [*channel_settings, updated_settings]
@@ -112,6 +122,8 @@ def update_channel_settings(
     channel: str,
     auth_type: str,
     username: str | None = None,
+    *,
+    allow_plaintext_http: bool = False,
 ) -> None:
     """
     Update the user's channel auth settings via conda's configuration file API.
@@ -125,6 +137,7 @@ def update_channel_settings(
         channel,
         auth_type,
         username,
+        allow_plaintext_http=allow_plaintext_http,
     )
 
 
@@ -188,7 +201,10 @@ def login(channel: Channel, **kwargs):
     Log in to a channel by storing the credentials or tokens associated with it
     """
     auth_type, auth_manager = get_auth_manager(**kwargs)
+    allow_plaintext_http = allows_plaintext_http(kwargs)
     extra_params = {param: kwargs.get(param) for param in auth_manager.get_config_parameters()}
+    if allow_plaintext_http:
+        extra_params[AUTH_ALLOW_PLAINTEXT_HTTP_PARAM] = True
     username, secret = auth_manager.fetch_secret(channel, extra_params, use_cache=False)
 
     try:
@@ -196,13 +212,24 @@ def login(channel: Channel, **kwargs):
         if auth_type == TOKEN_NAME:
             config_username = None
         with ConfigurationFile.from_user_condarc() as config:
-            update_channel_settings(config, channel.canonical_name, auth_type, config_username)
+            update_channel_settings(
+                config,
+                channel.canonical_name,
+                auth_type,
+                config_username,
+                allow_plaintext_http=allow_plaintext_http,
+            )
     except (CondaError, OSError, yaml.YAMLError) as exc:
         auth_manager.cache_clear(channel.canonical_name)
         raise CondaAuthError(str(exc))
 
     try:
-        auth_manager.save_credentials(channel, username, secret)
+        auth_manager.save_credentials(
+            channel,
+            username,
+            secret,
+            allow_plaintext_http=allow_plaintext_http,
+        )
     except Exception as credential_error:
         auth_manager.cache_clear(channel.canonical_name)
         try:
@@ -285,6 +312,11 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         "--password",
         help="Password to use for private channels using HTTP Basic Authentication",
     )
+    login_parser.add_argument(
+        "--allow-plaintext-http",
+        action="store_true",
+        help="Allow credentials to be used over plaintext HTTP for this channel",
+    )
     add_parser_json(login_parser)
     login_parser.set_defaults(parser=login_parser)
 
@@ -328,9 +360,21 @@ def auth(args: argparse.Namespace) -> None:
                 raise CondaAuthError("Option 'username' cannot be used with 'token'")
             if args.password is not None:
                 raise CondaAuthError("Option 'password' cannot be used with 'token'")
+
+        channel = Channel(args.channel)
+        validate_secure_channel(
+            channel,
+            allow_plaintext_http=args.allow_plaintext_http,
+        )
+
+        if token is not None:
             if token is PROMPT_VALUE:
                 token = prompt_secret("Token: ")
-            login(Channel(args.channel), token=token)
+            login(
+                channel,
+                token=token,
+                auth_allow_plaintext_http=args.allow_plaintext_http,
+            )
             output_success(args, SUCCESSFUL_LOGIN_MESSAGE)
             return
 
@@ -342,7 +386,13 @@ def auth(args: argparse.Namespace) -> None:
         if password is None:
             password = prompt_secret("Password: ")
 
-        login(Channel(args.channel), basic=True, username=username, password=password)
+        login(
+            channel,
+            basic=True,
+            username=username,
+            password=password,
+            auth_allow_plaintext_http=args.allow_plaintext_http,
+        )
         output_success(args, SUCCESSFUL_LOGIN_MESSAGE)
     elif args.command == "logout":
         logout(Channel(args.channel))

--- a/conda_auth/constants.py
+++ b/conda_auth/constants.py
@@ -3,3 +3,5 @@ A place for all of our constant variables
 """
 
 PLUGIN_NAME = "conda-auth"
+
+AUTH_ALLOW_PLAINTEXT_HTTP_PARAM = "auth_allow_plaintext_http"

--- a/conda_auth/handlers/base.py
+++ b/conda_auth/handlers/base.py
@@ -6,6 +6,7 @@ from fnmatch import fnmatch
 
 import conda.base.context
 from conda.base.context import context as global_context
+from conda.common.url import urlparse as conda_urlparse
 from conda.models.channel import Channel
 
 from ..storage import storage
@@ -90,6 +91,8 @@ class AuthManager(ABC):
             if settings.get("auth") != self.get_auth_type():
                 continue
             if configured_channel := settings.get("channel"):
+                if not isinstance(configured_channel, str):
+                    continue
                 if self.channel_matches(configured_channel, channel):
                     matched_settings = settings
 
@@ -97,16 +100,19 @@ class AuthManager(ABC):
 
     def channel_matches(self, configured_channel: str, channel: Channel) -> bool:
         """
-        Match configured channel names using conda's canonical channel names.
+        Match configured channel names the same way conda selects auth handlers.
         """
-        configured_canonical_name = Channel(configured_channel).canonical_name
+        if configured_channel == channel.canonical_name:
+            return True
 
-        return (
-            configured_channel == channel.canonical_name
-            or configured_canonical_name == channel.canonical_name
-            or fnmatch(channel.canonical_name, configured_channel)
-            or fnmatch(channel.canonical_name, configured_canonical_name)
-        )
+        parsed_channel = conda_urlparse(channel.base_url)
+        parsed_setting = conda_urlparse(configured_channel)
+        if parsed_setting.scheme != parsed_channel.scheme:
+            return False
+
+        channel_url = parsed_channel.netloc + parsed_channel.path
+        pattern = parsed_setting.netloc + parsed_setting.path
+        return fnmatch(channel_url, pattern)
 
     def cache_clear(self, channel_name: str | None = None) -> None:
         """

--- a/conda_auth/handlers/base.py
+++ b/conda_auth/handlers/base.py
@@ -3,13 +3,99 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from fnmatch import fnmatch
+from ipaddress import ip_address
+from urllib.parse import urlparse
 
 import conda.base.context
+from conda.auxlib.type_coercion import TypeCoercionError, boolify
 from conda.base.context import context as global_context
 from conda.common.url import urlparse as conda_urlparse
 from conda.models.channel import Channel
 
+from ..constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
+from ..exceptions import CondaAuthError
 from ..storage import storage
+
+
+def is_loopback_host(host: str | None) -> bool:
+    if host is None:
+        return False
+
+    if host.lower() == "localhost":
+        return True
+
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def get_url_host(url: str) -> str | None:
+    parsed_url = urlparse(url)
+    if parsed_url.hostname is not None:
+        return parsed_url.hostname
+
+    host = parsed_url.netloc.rsplit("@", 1)[-1]
+    host_without_port, _, port = host.rpartition(":")
+    if host.startswith("::1:") and port.isdigit():
+        return host_without_port
+
+    try:
+        ip_address(host)
+    except ValueError:
+        pass
+    else:
+        return host
+
+    if host.count(":") > 1:
+        if port.isdigit():
+            return host_without_port
+
+    if ":" in host:
+        host, _, _ = host.partition(":")
+
+    return host or None
+
+
+def allows_plaintext_http(settings: Mapping[str, object] | None) -> bool:
+    if settings is None:
+        return False
+
+    try:
+        return boolify(settings.get(AUTH_ALLOW_PLAINTEXT_HTTP_PARAM))
+    except TypeCoercionError:
+        return False
+
+
+def validate_secure_channel(
+    channel: Channel,
+    *,
+    allow_plaintext_http: bool = False,
+) -> None:
+    """
+    Prevent credentials from being sent over unsupported transports.
+    """
+    for url in channel.base_urls:
+        if url is None:
+            continue
+
+        parsed_url = urlparse(url)
+        if parsed_url.scheme == "https":
+            continue
+
+        if parsed_url.scheme == "http":
+            if allow_plaintext_http or is_loopback_host(get_url_host(url)):
+                continue
+
+            raise CondaAuthError(
+                "Refusing to use credentials over insecure HTTP channel "
+                f"{url!r}. Use HTTPS or localhost."
+            )
+
+        raise CondaAuthError(
+            "Refusing to use credentials with unsupported channel scheme "
+            f"{parsed_url.scheme!r} for {url!r}. Use HTTPS or localhost."
+        )
 
 
 class AuthManager(ABC):
@@ -28,36 +114,63 @@ class AuthManager(ABC):
         self._context = context or global_context
         self._cache = {} if cache is None else cache
 
-    def store(self, channel: Channel, settings: Mapping[str, str | None]) -> str:
+    def store(self, channel: Channel, settings: Mapping[str, object]) -> str:
         """
         Used to retrieve credentials and store them in the credential store.
 
         This method returns a "username" because this property could have been retrieved
         via user input while calling ``fetch_secret``.
         """
+        validate_secure_channel(
+            channel,
+            allow_plaintext_http=allows_plaintext_http(settings),
+        )
         extra_params = {param: settings.get(param) for param in self.get_config_parameters()}
+        if allows_plaintext_http(settings):
+            extra_params[AUTH_ALLOW_PLAINTEXT_HTTP_PARAM] = True
         username, secret = self.fetch_secret(channel, extra_params, use_cache=False)
 
-        self.save_credentials(channel, username, secret)
+        self.save_credentials(
+            channel,
+            username,
+            secret,
+            allow_plaintext_http=allows_plaintext_http(settings),
+        )
 
         return username
 
-    def save_credentials(self, channel: Channel, username: str, secret: str) -> None:
+    def save_credentials(
+        self,
+        channel: Channel,
+        username: str,
+        secret: str,
+        *,
+        allow_plaintext_http: bool = False,
+    ) -> None:
         """
         Saves the provided credentials to our credential store.
         """
+        validate_secure_channel(
+            channel,
+            allow_plaintext_http=allow_plaintext_http,
+        )
         storage.set_password(self.get_keyring_id(channel), username, secret)
 
     def fetch_secret(
         self,
         channel: Channel,
-        settings: Mapping[str, str | None],
+        settings: Mapping[str, object],
         *,
         use_cache: bool = True,
     ) -> tuple[str, str]:
         """
         Fetch secrets and handle updating cache.
         """
+        validate_secure_channel(
+            channel,
+            allow_plaintext_http=allows_plaintext_http(settings),
+        )
+
         if use_cache and (secrets := self._cache.get(channel.canonical_name)):
             return secrets
 
@@ -72,17 +185,21 @@ class AuthManager(ABC):
         """
         channel = Channel(channel_name)
         secrets = self._cache.get(channel.canonical_name)
+        settings = self.get_channel_settings(channel)
 
+        validate_secure_channel(
+            channel,
+            allow_plaintext_http=allows_plaintext_http(settings),
+        )
         if secrets is not None:
             return secrets
 
-        settings = self.get_channel_settings(channel)
         if settings is None:
             return None, None
 
         return self.fetch_secret(channel, settings)
 
-    def get_channel_settings(self, channel: Channel) -> Mapping[str, str | None] | None:
+    def get_channel_settings(self, channel: Channel) -> Mapping[str, object] | None:
         """
         Find the auth settings that apply to a channel.
         """
@@ -124,13 +241,11 @@ class AuthManager(ABC):
             self._cache.clear()
 
     @abstractmethod
-    def _fetch_secret(
-        self, channel: Channel, settings: Mapping[str, str | None]
-    ) -> tuple[str, str]:
+    def _fetch_secret(self, channel: Channel, settings: Mapping[str, object]) -> tuple[str, str]:
         """Implementations should include routine for fetching secret"""
 
     @abstractmethod
-    def remove_secret(self, channel: Channel, settings: Mapping[str, str]) -> None:
+    def remove_secret(self, channel: Channel, settings: Mapping[str, object]) -> None:
         """Implementations should include routine for removing secret"""
 
     @abstractmethod

--- a/conda_auth/handlers/basic_auth.py
+++ b/conda_auth/handlers/basic_auth.py
@@ -8,7 +8,7 @@ from collections.abc import Mapping
 
 from conda.models.channel import Channel
 from conda.plugins.types import ChannelAuthBase
-from requests.auth import _basic_auth_str
+from requests.auth import HTTPBasicAuth
 
 from ..constants import PLUGIN_NAME
 from ..exceptions import CondaAuthError
@@ -35,9 +35,7 @@ class BasicAuthManager(AuthManager):
     def get_keyring_id(self, channel: Channel):
         return f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel.canonical_name}"
 
-    def _fetch_secret(
-        self, channel: Channel, settings: Mapping[str, str | None]
-    ) -> tuple[str, str]:
+    def _fetch_secret(self, channel: Channel, settings: Mapping[str, object]) -> tuple[str, str]:
         """
         Gets the secrets by checking the keyring and then falling back to interrupting
         the program and asking the user for the credentials.
@@ -47,7 +45,7 @@ class BasicAuthManager(AuthManager):
 
         return username, password
 
-    def remove_secret(self, channel: Channel, settings: Mapping[str, str | None]) -> None:
+    def remove_secret(self, channel: Channel, settings: Mapping[str, object]) -> None:
         keyring_id = self.get_keyring_id(channel)
         username = self.get_username(settings)
 
@@ -59,25 +57,25 @@ class BasicAuthManager(AuthManager):
     def get_config_parameters(self) -> tuple[str, ...]:
         return USERNAME_PARAM_NAME, PASSWORD_PARAM_NAME
 
-    def get_username(self, settings: Mapping[str, str | None]):
+    def get_username(self, settings: Mapping[str, object]):
         """
         Attempts to find username in settings and falls back to prompting user for it if not found.
         """
         username = settings.get(USERNAME_PARAM_NAME)
 
-        if username is None:
+        if not isinstance(username, str):
             raise CondaAuthError("Username not found")
 
         return username
 
-    def get_password(
-        self, username: str, settings: Mapping[str, str | None], channel: Channel
-    ) -> str:
+    def get_password(self, username: str, settings: Mapping[str, object], channel: Channel) -> str:
         """
         Attempts to get password and falls back to prompting the user for it if not found.
         """
         # First see if a value has been passed in
         password = settings.get(PASSWORD_PARAM_NAME)
+        if password is not None and not isinstance(password, str):
+            raise CondaAuthError("Password not found")
 
         # Now try retrieving it from the password manager
         if password is None:
@@ -112,6 +110,7 @@ class BasicAuthHandler(ChannelAuthBase):
             raise CondaAuthError(
                 f"Unable to find user credentials for requests with channel {channel_name}"
             )
+        self._auth = HTTPBasicAuth(self.username, self.password)
 
     def __eq__(self, other):
         return all(
@@ -125,5 +124,4 @@ class BasicAuthHandler(ChannelAuthBase):
         return not self == other
 
     def __call__(self, r):
-        r.headers["Authorization"] = _basic_auth_str(self.username, self.password)
-        return r
+        return self._auth(r)

--- a/conda_auth/handlers/token.py
+++ b/conda_auth/handlers/token.py
@@ -35,15 +35,15 @@ class TokenAuthManager(AuthManager):
     def get_keyring_id(self, channel: Channel) -> str:
         return f"{PLUGIN_NAME}::{TOKEN_NAME}::{channel.canonical_name}"
 
-    def _fetch_secret(
-        self, channel: Channel, settings: Mapping[str, str | None]
-    ) -> tuple[str, str]:
+    def _fetch_secret(self, channel: Channel, settings: Mapping[str, object]) -> tuple[str, str]:
         """
         Gets the secrets by checking the keyring and then falling back to interrupting
         the program and asking the user for secret.
         """
         # First tried the value we passed in
         token = settings.get(TOKEN_PARAM_NAME)
+        if token is not None and not isinstance(token, str):
+            raise CondaAuthError("Token not found")
 
         if token is None:
             # Try password manager if there was nothing there
@@ -55,7 +55,7 @@ class TokenAuthManager(AuthManager):
 
         return USERNAME, token
 
-    def remove_secret(self, channel: Channel, settings: Mapping[str, str | None]) -> None:
+    def remove_secret(self, channel: Channel, settings: Mapping[str, object]) -> None:
         keyring_id = self.get_keyring_id(channel)
 
         storage.delete_password(keyring_id, USERNAME)

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -80,6 +80,95 @@ def test_login_validation_errors_raise_conda_error(runner, keyring, condarc, arg
     assert condarc.content == {}
 
 
+@pytest.mark.parametrize(
+    "args",
+    (
+        ["login", "http://example.com/private-channel", "--basic"],
+        ["login", "http://example.com/private-channel", "--token"],
+    ),
+    ids=("basic", "token"),
+)
+def test_login_rejects_plaintext_http_before_reading_secrets(
+    monkeypatch, runner, keyring, condarc, args
+):
+    """
+    Refuses to collect or store credentials for remote plaintext HTTP channels.
+    """
+
+    def fail_prompt(prompt):
+        raise AssertionError(f"Prompted for {prompt!r}")
+
+    # Transport validation happens before interactive secret prompts.
+    keyring_mock, _ = keyring(None)
+    monkeypatch.setattr("conda_auth.cli.prompt_text", fail_prompt)
+    monkeypatch.setattr("conda_auth.cli.prompt_secret", fail_prompt)
+
+    result = runner.invoke(auth, args)
+    exc_type, exception, _ = result.exc_info
+
+    assert result.exit_code == 1, result.output
+    assert exc_type == CondaAuthError
+    assert "insecure HTTP channel" in exception.message
+    keyring_mock.get_password.assert_not_called()
+    keyring_mock.set_password.assert_not_called()
+    assert condarc.content == {}
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_settings", "expected_keyring_call"),
+    (
+        (
+            [
+                "login",
+                "http://example.com/private-channel",
+                "--basic",
+                "--username",
+                "user",
+                "--password",
+                "password",
+                "--allow-plaintext-http",
+            ],
+            {
+                "channel": "http://example.com/private-channel",
+                "auth": "http-basic",
+                "username": "user",
+                "auth_allow_plaintext_http": True,
+            },
+            ("conda-auth::http-basic::http://example.com/private-channel", "user", "password"),
+        ),
+        (
+            [
+                "login",
+                "http://example.com/private-channel",
+                "--token",
+                "token",
+                "--allow-plaintext-http",
+            ],
+            {
+                "channel": "http://example.com/private-channel",
+                "auth": "token",
+                "auth_allow_plaintext_http": True,
+            },
+            ("conda-auth::token::http://example.com/private-channel", "token", "token"),
+        ),
+    ),
+    ids=("basic", "token"),
+)
+def test_login_allows_plaintext_http_when_explicit(
+    runner, keyring, condarc, args, expected_settings, expected_keyring_call
+):
+    """
+    Persists explicit plaintext HTTP opt-in with the channel auth settings.
+    """
+    keyring_mock, _ = keyring(None)
+
+    result = runner.invoke(auth, args)
+
+    assert result.exit_code == 0, result.output
+    assert condarc.content == {"channel_settings": [expected_settings]}
+    keyring_mock.set_password.assert_called_once_with(*expected_keyring_call)
+
+
 def test_login_error_when_updating_condarc_does_not_store_secret(runner, keyring, condarc):
     """
     Test the case where the login runs successfully but an error is returned when trying to update

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,75 @@
 import sys
 from contextlib import redirect_stderr, redirect_stdout
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from io import StringIO
+from typing import Any
 
 import pytest
+
+
+@dataclass
+class FakeContext:
+    channel_settings: list[dict[str, object]] = field(default_factory=list)
+    channels: tuple[str, ...] = ()
+
+
+@dataclass
+class FakeCondarc:
+    content: dict[str, Any] = field(default_factory=dict)
+    exit_side_effect: BaseException | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.exit_side_effect is not None:
+            raise self.exit_side_effect
+        return None
+
+
+@dataclass
+class FakeRequest:
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class RecordingKeyring:
+    secret: str | None
+    get_password_calls: list[tuple[str, str]] = field(default_factory=list)
+    set_password_calls: list[tuple[str, str, str]] = field(default_factory=list)
+    delete_password_calls: list[tuple[str, str]] = field(default_factory=list)
+    get_password_side_effect: BaseException | None = None
+    set_password_side_effect: BaseException | None = None
+    delete_password_side_effect: BaseException | None = None
+
+    def get_password(self, key_id: str, username: str) -> str | None:
+        self.get_password_calls.append((key_id, username))
+        if self.get_password_side_effect is not None:
+            raise self.get_password_side_effect
+        return self.secret
+
+    def set_password(self, key_id: str, username: str, password: str) -> None:
+        self.set_password_calls.append((key_id, username, password))
+        if self.set_password_side_effect is not None:
+            raise self.set_password_side_effect
+
+    def delete_password(self, key_id: str, username: str) -> None:
+        self.delete_password_calls.append((key_id, username))
+        if self.delete_password_side_effect is not None:
+            raise self.delete_password_side_effect
+
+
+@dataclass
+class RecordingGetKeyring:
+    backend: RecordingKeyring
+    side_effect: BaseException | type[BaseException] | None = None
+    calls: list[tuple] = field(default_factory=list)
+
+    def __call__(self):
+        self.calls.append(())
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.backend
 
 
 @dataclass
@@ -84,6 +150,19 @@ def runner():
     CLI test runner used for all tests
     """
     yield ArgparseRunner()
+
+
+@pytest.fixture
+def context_factory():
+    def _context_factory(channel_settings=None, channels=()):
+        return FakeContext(channel_settings=channel_settings or [], channels=channels)
+
+    return _context_factory
+
+
+@pytest.fixture
+def request_factory():
+    return FakeRequest
 
 
 @pytest.fixture

--- a/tests/handlers/test_base.py
+++ b/tests/handlers/test_base.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import pytest
+from conda.models.channel import Channel
+
+from conda_auth.constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
+from conda_auth.exceptions import CondaAuthError
+from conda_auth.handlers.base import (
+    allows_plaintext_http,
+    get_url_host,
+    is_loopback_host,
+    validate_secure_channel,
+)
+
+
+@pytest.mark.parametrize(
+    ("channel_name", "allow_plaintext_http"),
+    (
+        (None, False),
+        ("https://repo.example.com/private", False),
+        ("http://localhost:8080/private", False),
+        ("http://127.0.0.1:8080/private", False),
+        ("http://[::1]:8080/private", False),
+        ("http://example.com/private", True),
+    ),
+    ids=("unknown", "https", "localhost", "ipv4-loopback", "ipv6-loopback", "explicit-http"),
+)
+def test_validate_secure_channel_allows_supported_transports(channel_name, allow_plaintext_http):
+    validate_secure_channel(
+        Channel(channel_name),
+        allow_plaintext_http=allow_plaintext_http,
+    )
+
+
+@pytest.mark.parametrize(
+    ("channel_name", "message"),
+    (
+        ("http://example.com/private", "insecure HTTP channel"),
+        ("ftp://example.com/private", "unsupported channel scheme"),
+        ("s3://bucket/private", "unsupported channel scheme"),
+        ("file:///tmp/private", "unsupported channel scheme"),
+    ),
+    ids=("remote-http", "ftp", "s3", "file"),
+)
+def test_validate_secure_channel_rejects_unsupported_transports(channel_name, message):
+    with pytest.raises(CondaAuthError, match=message):
+        validate_secure_channel(Channel(channel_name))
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_host"),
+    (
+        ("http://::1:8080/private", "::1"),
+        ("http://::1/private", "::1"),
+        ("http://127.0.0.1:8080/private", "127.0.0.1"),
+        ("http://example.com/private", "example.com"),
+        ("http://", None),
+        ("http://::x:8080/private", "::x"),
+        ("http://:8080/private", None),
+    ),
+    ids=(
+        "ipv6-loopback-port",
+        "ipv6-loopback",
+        "ipv4-loopback",
+        "hostname",
+        "missing-host",
+        "unbracketed-invalid-ipv6-port",
+        "port-only",
+    ),
+)
+def test_get_url_host_handles_normalized_urls(url, expected_host):
+    assert get_url_host(url) == expected_host
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    (
+        (None, False),
+        ("LOCALHOST", True),
+        ("127.0.0.1", True),
+        ("::1", True),
+        ("repo.example.com", False),
+    ),
+    ids=("missing", "localhost", "ipv4", "ipv6", "remote"),
+)
+def test_is_loopback_host(host, expected):
+    assert is_loopback_host(host) is expected
+
+
+@pytest.mark.parametrize(
+    ("settings", "expected"),
+    (
+        (None, False),
+        ({AUTH_ALLOW_PLAINTEXT_HTTP_PARAM: True}, True),
+        ({AUTH_ALLOW_PLAINTEXT_HTTP_PARAM: "yes"}, True),
+        ({AUTH_ALLOW_PLAINTEXT_HTTP_PARAM: "not-a-boolean"}, False),
+    ),
+    ids=("missing", "boolean", "truthy-string", "invalid"),
+)
+def test_allows_plaintext_http(settings, expected):
+    assert allows_plaintext_http(settings) is expected

--- a/tests/handlers/test_basic_auth.py
+++ b/tests/handlers/test_basic_auth.py
@@ -6,11 +6,13 @@ import pytest
 from conda.exceptions import CondaError
 from conda.models.channel import Channel
 from keyring.errors import PasswordDeleteError
-from requests.auth import _basic_auth_str
+from requests.auth import HTTPBasicAuth
 
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.handlers.basic_auth import (
     HTTP_BASIC_AUTH_NAME,
+    PASSWORD_PARAM_NAME,
+    USERNAME_PARAM_NAME,
     BasicAuthHandler,
     BasicAuthManager,
     manager,
@@ -59,6 +61,24 @@ def test_basic_auth_manager_no_secret_or_username(keyring):
     # run code under test
     with pytest.raises(CondaAuthError, match="Username not found"):
         manager.store(channel, settings)
+
+
+@pytest.mark.parametrize(
+    ("settings", "message"),
+    (
+        ({USERNAME_PARAM_NAME: 1}, "Username not found"),
+        (
+            {USERNAME_PARAM_NAME: "admin", PASSWORD_PARAM_NAME: 1},
+            "Password not found",
+        ),
+    ),
+    ids=("username", "password"),
+)
+def test_basic_auth_manager_rejects_non_string_credentials(keyring, settings, message):
+    keyring(None)
+
+    with pytest.raises(CondaAuthError, match=message):
+        manager.store(Channel("tester"), settings)
 
 
 def test_basic_auth_manager_with_previous_secret(keyring):
@@ -185,8 +205,12 @@ def test_basic_auth_handler(mocker, keyring):
 
     request = auth_handler(request)
 
-    assert request.headers == {"Authorization": _basic_auth_str(username, password)}
-    keyring_mock.get_password.assert_called_once()
+    expected_request = MagicMock()
+    expected_request.headers = {}
+    HTTPBasicAuth(username, password)(expected_request)
+
+    assert request.headers == expected_request.headers
+    keyring_mock.get_password.assert_called_once_with("conda-auth::http-basic::channel", username)
     keyring_mock.set_password.assert_not_called()
 
 
@@ -245,6 +269,71 @@ def test_basic_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
     BasicAuthHandler(channel_name)
 
     keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("channel_name", "message"),
+    (
+        ("http://example.com/private-channel", "insecure HTTP channel"),
+        ("ftp://example.com/private-channel", "unsupported channel scheme"),
+        ("s3://bucket/private-channel", "unsupported channel scheme"),
+        ("file:///tmp/private-channel", "unsupported channel scheme"),
+    ),
+    ids=("remote-http", "ftp", "s3", "file"),
+)
+def test_basic_auth_handler_rejects_unsupported_transports_before_keyring(
+    monkeypatch, keyring, context_factory, channel_name, message
+):
+    """Unsupported transports never receive basic auth credentials."""
+    username = "username"
+
+    # Transport validation happens before reading the configured keyring secret.
+    context = context_factory(
+        [{"channel": channel_name, "auth": HTTP_BASIC_AUTH_NAME, "username": username}]
+    )
+    monkeypatch.setattr(manager, "_context", context)
+    keyring_mock, _ = keyring("password")
+
+    with pytest.raises(CondaAuthError, match=message):
+        BasicAuthHandler(channel_name)
+
+    keyring_mock.get_password.assert_not_called()
+    keyring_mock.set_password.assert_not_called()
+
+
+def test_basic_auth_handler_allows_plaintext_http_when_configured(
+    monkeypatch, keyring, context_factory, request_factory
+):
+    """Explicitly configured plaintext HTTP channels can receive basic auth."""
+    channel_name = "http://example.com/private-channel"
+    username = "username"
+    password = "password"
+
+    # The opt-in is read from channel_settings at request-auth time.
+    context = context_factory(
+        [
+            {
+                "channel": channel_name,
+                "auth": HTTP_BASIC_AUTH_NAME,
+                "username": username,
+                "auth_allow_plaintext_http": "True",
+            }
+        ]
+    )
+    monkeypatch.setattr(manager, "_context", context)
+    keyring_mock, _ = keyring(password)
+
+    auth_handler = BasicAuthHandler(channel_name)
+    request = auth_handler(request_factory())
+
+    expected_request = request_factory()
+    HTTPBasicAuth(username, password)(expected_request)
+
+    assert request.headers == expected_request.headers
+    keyring_mock.get_password.assert_called_once_with(
+        "conda-auth::http-basic::http://example.com/private-channel", username
+    )
     keyring_mock.set_password.assert_not_called()
 
 

--- a/tests/handlers/test_basic_auth.py
+++ b/tests/handlers/test_basic_auth.py
@@ -313,3 +313,56 @@ def test_basic_auth_manager_get_secret_loads_from_channel_settings(keyring):
 
     assert auth_manager.get_secret(channel) == (username, password)
     assert auth_manager._cache == {channel: (username, password)}
+
+
+@pytest.mark.parametrize(
+    ("configured_channel", "channel_name", "expected"),
+    (
+        ("conda-forge", "conda-forge", True),
+        ("https://repo.example.com/private", "https://repo.example.com/private", True),
+        ("https://repo.example.com/*", "https://repo.example.com/private", True),
+        ("http://repo.example.com/*", "https://repo.example.com/private", False),
+        ("*", "https://repo.example.com/private", False),
+    ),
+    ids=("named-exact", "url-exact", "url-pattern", "scheme-mismatch", "schemeless-glob"),
+)
+def test_basic_auth_manager_channel_matches_like_conda(configured_channel, channel_name, expected):
+    """Channel matching follows conda's auth-handler lookup rules."""
+    auth_manager = BasicAuthManager()
+
+    assert auth_manager.channel_matches(configured_channel, Channel(channel_name)) is expected
+
+
+def test_basic_auth_manager_get_channel_settings_uses_last_matching_setting():
+    """Matching settings use conda's last-match-wins behavior."""
+    channel_name = "https://repo.example.com/private"
+    context = MagicMock()
+    context.channel_settings = [
+        {
+            "channel": channel_name,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "exact",
+        },
+        {
+            "channel": 1,
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "invalid",
+        },
+        {
+            "channel": "https://repo.example.com/*",
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "wildcard",
+        },
+        {
+            "channel": "*",
+            "auth": HTTP_BASIC_AUTH_NAME,
+            "username": "schemeless",
+        },
+    ]
+    auth_manager = BasicAuthManager(context)
+
+    assert auth_manager.get_channel_settings(Channel(channel_name)) == {
+        "channel": "https://repo.example.com/*",
+        "auth": HTTP_BASIC_AUTH_NAME,
+        "username": "wildcard",
+    }

--- a/tests/handlers/test_token.py
+++ b/tests/handlers/test_token.py
@@ -7,9 +7,11 @@ from conda.exceptions import CondaError
 from conda.models.channel import Channel
 from keyring.errors import PasswordDeleteError
 
+from conda_auth.constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.handlers.token import (
     TOKEN_NAME,
+    TOKEN_PARAM_NAME,
     USERNAME,
     TokenAuthHandler,
     TokenAuthManager,
@@ -44,17 +46,18 @@ def test_is_anaconda_dot_org(channel_name, expected):
     assert is_anaconda_dot_org(channel_name) == expected
 
 
-def test_token_auth_manager_no_token(mocker, keyring):
+@pytest.mark.parametrize(
+    "settings",
+    ({}, {TOKEN_PARAM_NAME: 1}),
+    ids=("missing", "non-string"),
+)
+def test_token_auth_manager_rejects_missing_or_invalid_token(keyring, settings):
     """
-    Test to make sure when there is no token set, an exception is raised
+    Test to make sure missing and invalid tokens are rejected.
     """
-    token = "token"
-    settings = {}
     channel = Channel("tester")
 
     # setup mocks
-    input_mock = mocker.patch("conda_auth.handlers.token.input")
-    input_mock.return_value = token
     keyring(None)
 
     # run code under test
@@ -62,14 +65,24 @@ def test_token_auth_manager_no_token(mocker, keyring):
         manager.store(channel, settings)
 
 
-def test_token_auth_manager_with_token(keyring):
-    """
-    Test to make sure when there is a token set, we are able to set a new token via the ``input``
-    function.
-    """
-    token = "token"
-    settings = {"token": token}
-    channel = Channel("tester")
+@pytest.mark.parametrize(
+    ("channel_name", "settings"),
+    (
+        ("tester", {TOKEN_PARAM_NAME: "token"}),
+        (
+            "http://repo.example.com/private",
+            {
+                TOKEN_PARAM_NAME: "token",
+                AUTH_ALLOW_PLAINTEXT_HTTP_PARAM: True,
+            },
+        ),
+    ),
+    ids=("secure", "explicit-plaintext-http"),
+)
+def test_token_auth_manager_with_token(keyring, channel_name, settings):
+    """Valid tokens are cached for supported transports."""
+    token = settings[TOKEN_PARAM_NAME]
+    channel = Channel(channel_name)
 
     # setup mocks
     keyring(None)
@@ -193,6 +206,57 @@ def test_token_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
     TokenAuthHandler(channel_name)
 
     keyring_mock.get_password.assert_called_once()
+    keyring_mock.set_password.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("channel_name", "message"),
+    (
+        ("http://example.com/private-channel", "insecure HTTP channel"),
+        ("ftp://example.com/private-channel", "unsupported channel scheme"),
+        ("s3://bucket/private-channel", "unsupported channel scheme"),
+        ("file:///tmp/private-channel", "unsupported channel scheme"),
+    ),
+    ids=("remote-http", "ftp", "s3", "file"),
+)
+def test_token_auth_handler_rejects_unsupported_transports_before_keyring(
+    monkeypatch, keyring, context_factory, channel_name, message
+):
+    """Unsupported transports never receive token credentials."""
+
+    # Transport validation happens before reading the configured keyring token.
+    context = context_factory([{"channel": channel_name, "auth": TOKEN_NAME}])
+    monkeypatch.setattr(manager, "_context", context)
+    keyring_mock, _ = keyring("token")
+
+    with pytest.raises(CondaAuthError, match=message):
+        TokenAuthHandler(channel_name)
+
+    keyring_mock.get_password.assert_not_called()
+    keyring_mock.set_password.assert_not_called()
+
+
+def test_token_auth_handler_allows_plaintext_http_when_configured(
+    monkeypatch, keyring, context_factory, request_factory
+):
+    """Explicitly configured plaintext HTTP channels can receive token credentials."""
+    channel_name = "http://example.com/private-channel"
+    token = "token"
+
+    # The opt-in is read from channel_settings at request-auth time.
+    context = context_factory(
+        [{"channel": channel_name, "auth": TOKEN_NAME, "auth_allow_plaintext_http": "True"}]
+    )
+    monkeypatch.setattr(manager, "_context", context)
+    keyring_mock, _ = keyring(token)
+
+    auth_handler = TokenAuthHandler(channel_name)
+    request = auth_handler(request_factory())
+
+    assert request.headers == {"Authorization": f"Bearer {token}"}
+    keyring_mock.get_password.assert_called_once_with(
+        "conda-auth::token::http://example.com/private-channel", USERNAME
+    )
     keyring_mock.set_password.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Restricts authenticated requests to safe HTTP(S) channel transports, with explicit scoped opt-in for remote plaintext HTTP.

## Review Order
This PR is part of #42 and is ready for review after #57. Review #57 before this PR.

## Chain Tracker
- Previous: #57 Match channel auth settings like conda
- Current: #58 Harden auth transport handling
- Next: #59 Use structured credential storage and status
- Status: ready for review

## Issues
- Closes #53