### PR TITLE
[09/19] Use structured credential storage and status

### DIFF
--- a/conda_auth/cli.py
+++ b/conda_auth/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 from collections.abc import Mapping
+from fnmatch import fnmatch
 from getpass import getpass
 from typing import Literal
 
@@ -9,6 +10,7 @@ from conda.base.context import context
 from conda.cli.condarc import ConfigurationFile
 from conda.cli.helpers import add_parser_json
 from conda.common.serialize import json, yaml
+from conda.common.url import urlparse as conda_urlparse
 from conda.exceptions import CondaError
 from conda.models.channel import Channel
 
@@ -25,6 +27,7 @@ from .handlers.base import (
     allows_plaintext_http,
     validate_secure_channel,
 )
+from .storage import storage
 
 # Constants
 AUTH_MANAGER_MAPPING = {
@@ -44,6 +47,7 @@ AUTH_CHANNEL_SETTING_KEYS = frozenset(
         "username",
         "password",
         "token",
+        "auth_target",
         AUTH_ALLOW_PLAINTEXT_HTTP_PARAM,
     )
 )
@@ -79,6 +83,7 @@ def get_updated_channel_settings(
     auth_type: str,
     username: str | None = None,
     *,
+    auth_target: str | None = None,
     allow_plaintext_http: bool = False,
 ) -> list:
     """
@@ -103,6 +108,7 @@ def get_updated_channel_settings(
         )
 
     updated_settings["auth"] = auth_type
+    updated_settings["auth_target"] = auth_target or channel
     if username is not None:
         updated_settings["username"] = username
     if allow_plaintext_http:
@@ -123,6 +129,7 @@ def update_channel_settings(
     auth_type: str,
     username: str | None = None,
     *,
+    auth_target: str | None = None,
     allow_plaintext_http: bool = False,
 ) -> None:
     """
@@ -137,6 +144,7 @@ def update_channel_settings(
         channel,
         auth_type,
         username,
+        auth_target=auth_target,
         allow_plaintext_http=allow_plaintext_http,
     )
 
@@ -202,21 +210,26 @@ def login(channel: Channel, **kwargs):
     """
     auth_type, auth_manager = get_auth_manager(**kwargs)
     allow_plaintext_http = allows_plaintext_http(kwargs)
-    extra_params = {param: kwargs.get(param) for param in auth_manager.get_config_parameters()}
+    channel_setting = channel.canonical_name
+    credential_target = channel_setting
+    extra_params = {
+        param: kwargs.get(param)
+        for param in auth_manager.get_config_parameters()
+        if kwargs.get(param) is not None
+    }
+    extra_params["auth_target"] = credential_target
     if allow_plaintext_http:
         extra_params[AUTH_ALLOW_PLAINTEXT_HTTP_PARAM] = True
     username, secret = auth_manager.fetch_secret(channel, extra_params, use_cache=False)
 
     try:
-        config_username: str | None = username
-        if auth_type == TOKEN_NAME:
-            config_username = None
         with ConfigurationFile.from_user_condarc() as config:
             update_channel_settings(
                 config,
-                channel.canonical_name,
+                channel_setting,
                 auth_type,
-                config_username,
+                None,
+                auth_target=credential_target,
                 allow_plaintext_http=allow_plaintext_http,
             )
     except (CondaError, OSError, yaml.YAMLError) as exc:
@@ -229,12 +242,14 @@ def login(channel: Channel, **kwargs):
             username,
             secret,
             allow_plaintext_http=allow_plaintext_http,
+            target=credential_target,
+            settings=extra_params,
         )
     except Exception as credential_error:
         auth_manager.cache_clear(channel.canonical_name)
         try:
             with ConfigurationFile.from_user_condarc() as config:
-                remove_channel_settings(config, channel.canonical_name)
+                remove_channel_settings(config, channel_setting)
         except (CondaError, OSError, yaml.YAMLError) as rollback_error:
             raise CondaAuthError(
                 f"{credential_error}. Failed to roll back channel settings: {rollback_error}"
@@ -272,6 +287,125 @@ def logout(channel: Channel):
 
     auth_manager.remove_secret(channel, settings)
     auth_manager.cache_clear(channel.canonical_name)
+
+
+def get_status_entries(target: str | None = None) -> list[dict[str, object]]:
+    """
+    Return redacted credential status entries.
+    """
+    entries = []
+    for credential_target in get_status_targets(target):
+        record = storage.get_credential(credential_target)
+        if record is not None:
+            entries.append(record.to_status_entry())
+    return entries
+
+
+def get_status_targets(target: str | None = None) -> tuple[str, ...]:
+    """
+    Return known configured credential targets for status output.
+    """
+    seen = set()
+    targets: list[str] = []
+
+    def add(candidate: str | None) -> None:
+        if candidate is not None and candidate not in seen:
+            seen.add(candidate)
+            targets.append(candidate)
+
+    requested_channel = Channel(target) if target is not None else None
+    requested_keys = set()
+    if target is not None and requested_channel is not None:
+        requested_keys.update((target, requested_channel.canonical_name))
+        add(target)
+        add(requested_channel.canonical_name)
+
+    for settings in context.channel_settings:
+        if not isinstance(settings, Mapping) or not settings.get("auth"):
+            continue
+
+        configured_channel = settings.get("channel")
+        if not isinstance(configured_channel, str):
+            continue
+
+        auth_target = settings.get("auth_target")
+        if not isinstance(auth_target, str):
+            auth_target = configured_channel
+
+        if requested_channel is None:
+            add(auth_target)
+        elif status_setting_matches_target(
+            configured_channel,
+            auth_target,
+            requested_channel,
+            requested_keys,
+        ):
+            add(auth_target)
+
+    return tuple(targets)
+
+
+def status_setting_matches_target(
+    configured_channel: str,
+    auth_target: str,
+    requested_channel: Channel,
+    requested_keys: set[str],
+) -> bool:
+    """
+    Return whether a configured auth setting applies to an explicit status target.
+    """
+    return (
+        configured_channel in requested_keys
+        or auth_target in requested_keys
+        or channel_matches(configured_channel, requested_channel)
+        or channel_matches(auth_target, requested_channel)
+    )
+
+
+def channel_matches(configured_channel: str, channel: Channel) -> bool:
+    """
+    Match configured channel names the same way conda selects auth handlers.
+    """
+    if configured_channel == channel.canonical_name:
+        return True
+
+    parsed_channel = conda_urlparse(channel.base_url)
+    parsed_setting = conda_urlparse(configured_channel)
+    if parsed_setting.scheme != parsed_channel.scheme:
+        return False
+
+    channel_url = parsed_channel.netloc + parsed_channel.path
+    pattern = parsed_setting.netloc + parsed_setting.path
+    return fnmatch(channel_url, pattern)
+
+
+def status(target: str | None = None) -> list[dict[str, object]]:
+    """
+    Return stored credential status entries.
+    """
+    return get_status_entries(target)
+
+
+def output_status(args: argparse.Namespace, entries: list[dict[str, object]]) -> None:
+    """
+    Output credential status in text or JSON form.
+    """
+    if getattr(args, "json", False) is True:
+        print(json.dumps({"success": True, "credentials": entries}))
+        return
+
+    if not entries:
+        print("No credentials stored")
+        return
+
+    for entry in entries:
+        target = entry.get("target", "<unknown>")
+        auth_type = entry.get("auth_type", "<unknown>")
+        expires_at = entry.get("expires_at")
+        details = [f"{target}: {auth_type}"]
+        if expires_at is not None:
+            details.append(f"expires_at={expires_at}")
+        print(" ".join(details))
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
@@ -327,6 +461,14 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
     )
     logout_parser.add_argument("channel")
     add_parser_json(logout_parser)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Show stored credentials",
+        description="Show stored credentials for authenticated channels",
+    )
+    status_parser.add_argument("channel", nargs="?")
+    add_parser_json(status_parser)
 
 
 def build_parser(prog_name: str = "conda auth") -> argparse.ArgumentParser:
@@ -397,3 +539,5 @@ def auth(args: argparse.Namespace) -> None:
     elif args.command == "logout":
         logout(Channel(args.channel))
         output_success(args, SUCCESSFUL_LOGOUT_MESSAGE)
+    elif args.command == "status":
+        output_status(args, status(args.channel))

--- a/conda_auth/credentials.py
+++ b/conda_auth/credentials.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class CredentialRecord:
+    """
+    Structured credential payload stored in the configured credential backend.
+    """
+
+    target: str
+    """Storage lookup key and scope for the credential."""
+
+    auth_type: str
+    """Authentication mechanism that consumes the credential."""
+
+    username: str | None = None
+    """Username for HTTP Basic authentication."""
+
+    password: str | None = None
+    """Password for HTTP Basic authentication."""
+
+    token: str | None = None
+    """Static token used by token authentication."""
+
+    token_header: str | None = None
+    """HTTP request header that carries the static token."""
+
+    token_template: str | None = None
+    """Format string used to build the token header value."""
+
+    access_token: str | None = None
+    """OAuth 2.0 bearer token used for authenticated requests."""
+
+    refresh_token: str | None = None
+    """OAuth 2.0 token used to obtain a new access token."""
+
+    expires_at: int | None = None
+    """Access token expiration time as a Unix timestamp."""
+
+    token_endpoint: str | None = None
+    """OAuth 2.0 endpoint used to refresh an access token."""
+
+    revocation_endpoint: str | None = None
+    """OAuth 2.0 endpoint used to revoke tokens on logout."""
+
+    client_id: str | None = None
+    """OAuth 2.0 client identifier used for refresh and revocation."""
+
+    issuer_url: str | None = None
+    """OAuth 2.0 issuer URL used for discovery and status output."""
+
+    scopes: tuple[str, ...] = ()
+    """OAuth 2.0 scopes requested when obtaining the credential."""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> CredentialRecord:
+        scopes = data.get("scopes", ())
+        if isinstance(scopes, list):
+            scopes = tuple(str(scope) for scope in scopes)
+        elif isinstance(scopes, tuple):
+            scopes = tuple(str(scope) for scope in scopes)
+        else:
+            scopes = ()
+
+        return cls(
+            target=str(data["target"]),
+            auth_type=str(data["auth_type"]),
+            username=_optional_str(data.get("username")),
+            password=_optional_str(data.get("password")),
+            token=_optional_str(data.get("token")),
+            token_header=_optional_str(data.get("token_header")),
+            token_template=_optional_str(data.get("token_template")),
+            access_token=_optional_str(data.get("access_token")),
+            refresh_token=_optional_str(data.get("refresh_token")),
+            expires_at=_optional_int(data.get("expires_at")),
+            token_endpoint=_optional_str(data.get("token_endpoint")),
+            revocation_endpoint=_optional_str(data.get("revocation_endpoint")),
+            client_id=_optional_str(data.get("client_id")),
+            issuer_url=_optional_str(data.get("issuer_url")),
+            scopes=scopes,
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in {
+                "target": self.target,
+                "auth_type": self.auth_type,
+                "username": self.username,
+                "password": self.password,
+                "token": self.token,
+                "token_header": self.token_header,
+                "token_template": self.token_template,
+                "access_token": self.access_token,
+                "refresh_token": self.refresh_token,
+                "expires_at": self.expires_at,
+                "token_endpoint": self.token_endpoint,
+                "revocation_endpoint": self.revocation_endpoint,
+                "client_id": self.client_id,
+                "issuer_url": self.issuer_url,
+                "scopes": list(self.scopes),
+            }.items()
+            if value is not None and value != []
+        }
+
+    def to_status_entry(self) -> dict[str, Any]:
+        return {
+            key: value
+            for key, value in {
+                "target": self.target,
+                "auth_type": self.auth_type,
+                "username": self.username,
+                "issuer_url": self.issuer_url,
+                "expires_at": self.expires_at,
+            }.items()
+            if value is not None
+        }
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None

--- a/conda_auth/handlers/base.py
+++ b/conda_auth/handlers/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from dataclasses import replace
 from fnmatch import fnmatch
 from ipaddress import ip_address
 from urllib.parse import urlparse
@@ -13,6 +14,7 @@ from conda.common.url import urlparse as conda_urlparse
 from conda.models.channel import Channel
 
 from ..constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
+from ..credentials import CredentialRecord
 from ..exceptions import CondaAuthError
 from ..storage import storage
 
@@ -135,6 +137,7 @@ class AuthManager(ABC):
             username,
             secret,
             allow_plaintext_http=allows_plaintext_http(settings),
+            settings=extra_params,
         )
 
         return username
@@ -146,7 +149,9 @@ class AuthManager(ABC):
         secret: str,
         *,
         allow_plaintext_http: bool = False,
-    ) -> None:
+        target: str | None = None,
+        settings: Mapping[str, object] | None = None,
+    ) -> CredentialRecord:
         """
         Saves the provided credentials to our credential store.
         """
@@ -154,7 +159,96 @@ class AuthManager(ABC):
             channel,
             allow_plaintext_http=allow_plaintext_http,
         )
-        storage.set_password(self.get_keyring_id(channel), username, secret)
+        record = self.create_credential_record(channel, username, secret, settings)
+        if target is not None:
+            record = replace(record, target=target)
+        storage.set_credential(record)
+        return record
+
+    def create_credential_record(
+        self,
+        channel: Channel,
+        username: str,
+        secret: str,
+        settings: Mapping[str, object] | None = None,
+    ) -> CredentialRecord:
+        """
+        Build the structured credential payload persisted by this manager.
+        """
+        return CredentialRecord(
+            target=channel.canonical_name,
+            auth_type=self.get_auth_type(),
+            username=username,
+            password=secret,
+        )
+
+    def get_credential_target(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None = None,
+    ) -> str:
+        if settings is not None:
+            target = settings.get("auth_target")
+            if isinstance(target, str):
+                return target
+        return channel.canonical_name
+
+    def get_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None = None,
+    ) -> CredentialRecord | None:
+        """
+        Return the structured credential record for a channel, if present.
+        """
+        target = self.get_credential_target(channel, settings)
+        record = storage.get_credential(target)
+        if record is not None:
+            return record
+
+        return self.migrate_legacy_credential_record(channel, settings, target)
+
+    def migrate_legacy_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None,
+        target: str,
+    ) -> CredentialRecord | None:
+        """
+        Migrate a pre-structured keyring entry for a channel, if this manager supports one.
+        """
+        return None
+
+    def legacy_credential_targets(self, channel: Channel, target: str) -> tuple[str, ...]:
+        """
+        Return possible pre-structured keyring targets for a channel.
+        """
+        targets = [target]
+        if channel.canonical_name != target:
+            targets.append(channel.canonical_name)
+        return tuple(targets)
+
+    def delete_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None = None,
+    ) -> None:
+        """
+        Delete the structured credential record for a channel.
+        """
+        target = self.get_credential_target(channel, settings)
+        storage.delete_credential(target)
+        self.delete_legacy_credential_record(channel, settings, target)
+
+    def delete_legacy_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None,
+        target: str,
+    ) -> None:
+        """
+        Delete a pre-structured keyring entry for a channel, if this manager supports one.
+        """
 
     def fetch_secret(
         self,
@@ -260,12 +354,6 @@ class AuthManager(ABC):
         """
         Implementations should return a ``tuple`` of ``str`` which represent the configuration
         values to use in the ``context.channel_settings`` object.
-        """
-
-    @abstractmethod
-    def get_keyring_id(self, channel: Channel) -> str:
-        """
-        Implementation should return the keyring id that will be used by the manager classes
         """
 
     @abstractmethod

--- a/conda_auth/handlers/basic_auth.py
+++ b/conda_auth/handlers/basic_auth.py
@@ -5,14 +5,16 @@ Basic auth implementation for the conda auth handler plugin hook
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 
 from conda.models.channel import Channel
 from conda.plugins.types import ChannelAuthBase
 from requests.auth import HTTPBasicAuth
 
-from ..constants import PLUGIN_NAME
+from ..credentials import CredentialRecord
 from ..exceptions import CondaAuthError
 from ..storage import storage
+from ..storage.keyring import KeyringStorage
 from .base import AuthManager
 
 USERNAME_PARAM_NAME: str = "username"
@@ -32,24 +34,19 @@ Name used to refer to this authentication handler in configuration
 
 
 class BasicAuthManager(AuthManager):
-    def get_keyring_id(self, channel: Channel):
-        return f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel.canonical_name}"
-
     def _fetch_secret(self, channel: Channel, settings: Mapping[str, object]) -> tuple[str, str]:
         """
         Gets the secrets by checking the keyring and then falling back to interrupting
         the program and asking the user for the credentials.
         """
-        username = self.get_username(settings)
-        password = self.get_password(username, settings, channel)
+        record = self.get_credential_record(channel, settings)
+        username = self.get_username(settings, record)
+        password = self.get_password(username, settings, record)
 
         return username, password
 
     def remove_secret(self, channel: Channel, settings: Mapping[str, object]) -> None:
-        keyring_id = self.get_keyring_id(channel)
-        username = self.get_username(settings)
-
-        storage.delete_password(keyring_id, username)
+        self.delete_credential_record(channel, settings)
 
     def get_auth_type(self) -> str:
         return HTTP_BASIC_AUTH_NAME
@@ -57,18 +54,30 @@ class BasicAuthManager(AuthManager):
     def get_config_parameters(self) -> tuple[str, ...]:
         return USERNAME_PARAM_NAME, PASSWORD_PARAM_NAME
 
-    def get_username(self, settings: Mapping[str, object]):
+    def get_username(
+        self,
+        settings: Mapping[str, object],
+        record: CredentialRecord | None = None,
+    ) -> str:
         """
         Attempts to find username in settings and falls back to prompting user for it if not found.
         """
         username = settings.get(USERNAME_PARAM_NAME)
+
+        if not isinstance(username, str) and record is not None:
+            username = record.username
 
         if not isinstance(username, str):
             raise CondaAuthError("Username not found")
 
         return username
 
-    def get_password(self, username: str, settings: Mapping[str, object], channel: Channel) -> str:
+    def get_password(
+        self,
+        username: str,
+        settings: Mapping[str, object],
+        record: CredentialRecord | None = None,
+    ) -> str:
         """
         Attempts to get password and falls back to prompting the user for it if not found.
         """
@@ -77,15 +86,76 @@ class BasicAuthManager(AuthManager):
         if password is not None and not isinstance(password, str):
             raise CondaAuthError("Password not found")
 
-        # Now try retrieving it from the password manager
-        if password is None:
-            keyring_id = self.get_keyring_id(channel)
-            password = storage.get_password(keyring_id, username)
+        if password is None and record is not None and record.username == username:
+            password = record.password
 
-            if password is None:
-                raise CondaAuthError("Password not found")
+        if password is None:
+            raise CondaAuthError("Password not found")
 
         return password
+
+    def create_credential_record(
+        self,
+        channel: Channel,
+        username: str,
+        secret: str,
+        settings: Mapping[str, object] | None = None,
+    ) -> CredentialRecord:
+        return CredentialRecord(
+            target=channel.canonical_name,
+            auth_type=HTTP_BASIC_AUTH_NAME,
+            username=username,
+            password=secret,
+        )
+
+    def migrate_legacy_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None,
+        target: str,
+    ) -> CredentialRecord | None:
+        if settings is None:
+            return None
+
+        username = settings.get(USERNAME_PARAM_NAME)
+        if not isinstance(username, str):
+            return None
+
+        backend = storage.backend
+        if not isinstance(backend, KeyringStorage):
+            return None
+
+        for legacy_target in self.legacy_credential_targets(channel, target):
+            password = backend.get_legacy_password(HTTP_BASIC_AUTH_NAME, legacy_target, username)
+            if password is None:
+                continue
+
+            record = self.create_credential_record(channel, username, password, settings)
+            if record.target != target:
+                record = replace(record, target=target)
+            return record
+
+        return None
+
+    def delete_legacy_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None,
+        target: str,
+    ) -> None:
+        if settings is None:
+            return
+
+        username = settings.get(USERNAME_PARAM_NAME)
+        if not isinstance(username, str):
+            return
+
+        backend = storage.backend
+        if not isinstance(backend, KeyringStorage):
+            return
+
+        for legacy_target in self.legacy_credential_targets(channel, target):
+            backend.delete_legacy_password(HTTP_BASIC_AUTH_NAME, legacy_target, username)
 
     def get_auth_class(self) -> type:
         return BasicAuthHandler
@@ -124,4 +194,6 @@ class BasicAuthHandler(ChannelAuthBase):
         return not self == other
 
     def __call__(self, r):
+        if "Authorization" in r.headers:
+            return r
         return self._auth(r)

--- a/conda_auth/handlers/token.py
+++ b/conda_auth/handlers/token.py
@@ -5,14 +5,16 @@ Token implementation for the conda auth handler plugin hook
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from urllib.parse import urlparse
 
 from conda.models.channel import Channel
 from conda.plugins.types import ChannelAuthBase
 
-from ..constants import PLUGIN_NAME
+from ..credentials import CredentialRecord
 from ..exceptions import CondaAuthError
 from ..storage import storage
+from ..storage.keyring import KeyringStorage
 from .base import AuthManager
 
 TOKEN_PARAM_NAME: str = "token"
@@ -32,33 +34,28 @@ Name used to refer to this authentication handler in configuration
 
 
 class TokenAuthManager(AuthManager):
-    def get_keyring_id(self, channel: Channel) -> str:
-        return f"{PLUGIN_NAME}::{TOKEN_NAME}::{channel.canonical_name}"
-
     def _fetch_secret(self, channel: Channel, settings: Mapping[str, object]) -> tuple[str, str]:
         """
         Gets the secrets by checking the keyring and then falling back to interrupting
         the program and asking the user for secret.
         """
-        # First tried the value we passed in
+        record = self.get_credential_record(channel, settings)
+
+        # First try the value we passed in.
         token = settings.get(TOKEN_PARAM_NAME)
         if token is not None and not isinstance(token, str):
             raise CondaAuthError("Token not found")
 
-        if token is None:
-            # Try password manager if there was nothing there
-            keyring_id = self.get_keyring_id(channel)
-            token = storage.get_password(keyring_id, USERNAME)
+        if token is None and record is not None:
+            token = record.token
 
-            if token is None:
-                raise CondaAuthError("Token not found")
+        if token is None:
+            raise CondaAuthError("Token not found")
 
         return USERNAME, token
 
     def remove_secret(self, channel: Channel, settings: Mapping[str, object]) -> None:
-        keyring_id = self.get_keyring_id(channel)
-
-        storage.delete_password(keyring_id, USERNAME)
+        self.delete_credential_record(channel, settings)
 
     def get_auth_type(self) -> str:
         return TOKEN_NAME
@@ -68,6 +65,55 @@ class TokenAuthManager(AuthManager):
 
     def get_auth_class(self) -> type:
         return TokenAuthHandler
+
+    def create_credential_record(
+        self,
+        channel: Channel,
+        username: str,
+        secret: str,
+        settings: Mapping[str, object] | None = None,
+    ) -> CredentialRecord:
+        return CredentialRecord(
+            target=channel.canonical_name,
+            auth_type=TOKEN_NAME,
+            username=username,
+            token=secret,
+        )
+
+    def migrate_legacy_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None,
+        target: str,
+    ) -> CredentialRecord | None:
+        backend = storage.backend
+        if not isinstance(backend, KeyringStorage):
+            return None
+
+        for legacy_target in self.legacy_credential_targets(channel, target):
+            token = backend.get_legacy_password(TOKEN_NAME, legacy_target, USERNAME)
+            if token is None:
+                continue
+
+            record = self.create_credential_record(channel, USERNAME, token, settings)
+            if record.target != target:
+                record = replace(record, target=target)
+            return record
+
+        return None
+
+    def delete_legacy_credential_record(
+        self,
+        channel: Channel,
+        settings: Mapping[str, object] | None,
+        target: str,
+    ) -> None:
+        backend = storage.backend
+        if not isinstance(backend, KeyringStorage):
+            return
+
+        for legacy_target in self.legacy_credential_targets(channel, target):
+            backend.delete_legacy_password(TOKEN_NAME, legacy_target, USERNAME)
 
 
 manager = TokenAuthManager()

--- a/conda_auth/storage/__init__.py
+++ b/conda_auth/storage/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from keyring import get_keyring
 from keyring.errors import NoKeyringError
 
+from ..credentials import CredentialRecord
 from ..exceptions import CondaAuthError
 from .base import Storage
 from .keyring import KeyringStorage
@@ -44,14 +45,14 @@ class LazyStorage(Storage):
 
         return self._storage
 
-    def get_password(self, key_id: str, username: str) -> str | None:
-        return self.backend.get_password(key_id, username)
+    def set_credential(self, record: CredentialRecord) -> None:
+        return self.backend.set_credential(record)
 
-    def set_password(self, key_id: str, username: str, password: str) -> None:
-        return self.backend.set_password(key_id, username, password)
+    def get_credential(self, target: str) -> CredentialRecord | None:
+        return self.backend.get_credential(target)
 
-    def delete_password(self, key_id: str, username: str) -> None:
-        return self.backend.delete_password(key_id, username)
+    def delete_credential(self, target: str) -> None:
+        return self.backend.delete_credential(target)
 
 
 storage = LazyStorage()

--- a/conda_auth/storage/base.py
+++ b/conda_auth/storage/base.py
@@ -2,24 +2,26 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from ..credentials import CredentialRecord
+
 
 class Storage(ABC):
     """ABC class for all credential storage backends"""
 
     @abstractmethod
-    def set_password(self, key_id: str, username: str, password: str) -> None:
+    def set_credential(self, record: CredentialRecord) -> None:
         """
-        Sets the password for a specific ``key_id``
-        """
-
-    @abstractmethod
-    def get_password(self, key_id: str, username: str) -> str | None:
-        """
-        Gets the password for a specific ``key_id``
+        Store a structured credential record.
         """
 
     @abstractmethod
-    def delete_password(self, key_id: str, username: str) -> None:
+    def get_credential(self, target: str) -> CredentialRecord | None:
         """
-        Deletes the password for a specific ``key_id``
+        Return a structured credential record for a target.
+        """
+
+    @abstractmethod
+    def delete_credential(self, target: str) -> None:
+        """
+        Delete a structured credential record for a target.
         """

--- a/conda_auth/storage/keyring.py
+++ b/conda_auth/storage/keyring.py
@@ -1,10 +1,20 @@
 from __future__ import annotations
 
+import json
+from json import JSONDecodeError
+
 import keyring
 from keyring.errors import PasswordDeleteError
 
+from ..constants import PLUGIN_NAME
+from ..credentials import (
+    CredentialRecord,
+)
 from ..exceptions import CondaAuthError
 from .base import Storage
+
+KEYRING_CREDENTIAL_SERVICE_PREFIX = f"{PLUGIN_NAME}::credential"
+KEYRING_CREDENTIAL_USERNAME = "credential"
 
 
 class KeyringStorage(Storage):
@@ -12,14 +22,60 @@ class KeyringStorage(Storage):
     Storage implementation for keyring library
     """
 
-    def get_password(self, key_id: str, username: str) -> str | None:
-        return keyring.get_password(key_id, username)
+    def set_credential(self, record: CredentialRecord) -> None:
+        keyring.set_password(
+            f"{KEYRING_CREDENTIAL_SERVICE_PREFIX}::{record.target}",
+            KEYRING_CREDENTIAL_USERNAME,
+            json.dumps(record.to_dict()),
+        )
 
-    def set_password(self, key_id: str, username: str, password: str) -> None:
-        return keyring.set_password(key_id, username, password)
+    def get_credential(self, target: str) -> CredentialRecord | None:
+        payload = keyring.get_password(
+            f"{KEYRING_CREDENTIAL_SERVICE_PREFIX}::{target}",
+            KEYRING_CREDENTIAL_USERNAME,
+        )
+        if payload is None:
+            return None
 
-    def delete_password(self, key_id: str, username: str) -> None:
         try:
-            return keyring.delete_password(key_id, username)
-        except PasswordDeleteError as exc:
-            raise CondaAuthError(f"Unable to remove secret: {exc}")
+            data = json.loads(payload)
+        except (JSONDecodeError, TypeError) as exc:
+            raise CondaAuthError(f"Unable to read stored credential for {target!r}: {exc}")
+
+        if not isinstance(data, dict):
+            raise CondaAuthError(f"Stored credential for {target!r} is invalid")
+
+        return CredentialRecord.from_dict(data)
+
+    def delete_credential(self, target: str) -> None:
+        try:
+            keyring.delete_password(
+                f"{KEYRING_CREDENTIAL_SERVICE_PREFIX}::{target}",
+                KEYRING_CREDENTIAL_USERNAME,
+            )
+        except PasswordDeleteError:
+            pass
+
+    def legacy_service_name(self, auth_type: str, target: str) -> str:
+        """
+        Return the keyring service name used before structured records.
+        """
+        return f"{PLUGIN_NAME}::{auth_type}::{target}"
+
+    def get_legacy_password(self, auth_type: str, target: str, username: str) -> str | None:
+        """
+        Return an old password-shaped keyring credential, if present.
+        """
+        return keyring.get_password(self.legacy_service_name(auth_type, target), username)
+
+    def delete_legacy_password(self, auth_type: str, target: str, username: str) -> None:
+        """
+        Best-effort deletion for an old password-shaped keyring credential.
+        """
+        service_name = self.legacy_service_name(auth_type, target)
+        try:
+            if keyring.get_password(service_name, username) is None:
+                return
+            keyring.delete_password(service_name, username)
+        except PasswordDeleteError:
+            pass

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -115,7 +115,7 @@ def test_login_rejects_plaintext_http_before_reading_secrets(
 
 
 @pytest.mark.parametrize(
-    ("args", "expected_settings", "expected_keyring_call"),
+    ("args", "expected_settings", "expected_record"),
     (
         (
             [
@@ -131,10 +131,15 @@ def test_login_rejects_plaintext_http_before_reading_secrets(
             {
                 "channel": "http://example.com/private-channel",
                 "auth": "http-basic",
-                "username": "user",
+                "auth_target": "http://example.com/private-channel",
                 "auth_allow_plaintext_http": True,
             },
-            ("conda-auth::http-basic::http://example.com/private-channel", "user", "password"),
+            {
+                "target": "http://example.com/private-channel",
+                "auth_type": "http-basic",
+                "username": "user",
+                "password": "password",
+            },
         ),
         (
             [
@@ -147,15 +152,21 @@ def test_login_rejects_plaintext_http_before_reading_secrets(
             {
                 "channel": "http://example.com/private-channel",
                 "auth": "token",
+                "auth_target": "http://example.com/private-channel",
                 "auth_allow_plaintext_http": True,
             },
-            ("conda-auth::token::http://example.com/private-channel", "token", "token"),
+            {
+                "target": "http://example.com/private-channel",
+                "auth_type": "token",
+                "username": "token",
+                "token": "token",
+            },
         ),
     ),
     ids=("basic", "token"),
 )
 def test_login_allows_plaintext_http_when_explicit(
-    runner, keyring, condarc, args, expected_settings, expected_keyring_call
+    runner, keyring, condarc, args, expected_settings, expected_record
 ):
     """
     Persists explicit plaintext HTTP opt-in with the channel auth settings.
@@ -166,7 +177,11 @@ def test_login_allows_plaintext_http_when_explicit(
 
     assert result.exit_code == 0, result.output
     assert condarc.content == {"channel_settings": [expected_settings]}
-    keyring_mock.set_password.assert_called_once_with(*expected_keyring_call)
+    keyring_mock.set_password.assert_called_once()
+    key, username, payload = keyring_mock.set_password_calls[0]
+    assert key == "conda-auth::credential::http://example.com/private-channel"
+    assert username == "credential"
+    assert json.loads(payload) == expected_record
 
 
 def test_login_error_when_updating_condarc_does_not_store_secret(runner, keyring, condarc):

--- a/tests/cli/test_logout.py
+++ b/tests/cli/test_logout.py
@@ -3,7 +3,6 @@ import json
 from conda.exceptions import CondaError
 
 from conda_auth.cli import SUCCESSFUL_LOGOUT_MESSAGE, auth
-from conda_auth.constants import PLUGIN_NAME
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.handlers.basic_auth import HTTP_BASIC_AUTH_NAME, manager
 
@@ -41,10 +40,10 @@ def test_logout_of_active_session(mocker, runner, keyring, condarc):
     assert SUCCESSFUL_LOGOUT_MESSAGE in result.output
     assert result.exit_code == 0, result.output
 
-    keyring_mock.delete_password.assert_called_once_with(
-        f"{PLUGIN_NAME}::{HTTP_BASIC_AUTH_NAME}::{channel_name}",
-        username,
-    )
+    assert keyring_mock.delete_password_calls == [
+        ("conda-auth::credential::tester", "credential"),
+        ("conda-auth::http-basic::tester", username),
+    ]
     assert channel_name not in manager._cache
     assert condarc.content == {
         "channel_settings": [

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -1,0 +1,152 @@
+import json
+
+import pytest
+from conda.models.channel import Channel
+
+from conda_auth.cli import auth, channel_matches, get_status_targets
+from conda_auth.credentials import CredentialRecord
+from conda_auth.storage.keyring import KeyringStorage
+
+
+def test_status_lists_configured_stored_credentials(mocker, runner, keyring):
+    """
+    Status lists records that are both configured and present in storage.
+    """
+    keyring(None)
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [
+        {"channel": "tester", "auth": "token", "auth_target": "tester"}
+    ]
+    KeyringStorage().set_credential(
+        CredentialRecord(
+            target="tester",
+            auth_type="token",
+            username="token",
+            token="secret-token",
+        )
+    )
+
+    result = runner.invoke(auth, ["status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "success": True,
+        "credentials": [{"target": "tester", "auth_type": "token", "username": "token"}],
+    }
+
+
+def test_status_does_not_list_unconfigured_storage_records(mocker, runner, keyring):
+    """
+    Status derives listable targets from conda auth config, not secret enumeration.
+    """
+    keyring(None)
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = []
+    KeyringStorage().set_credential(
+        CredentialRecord(target="tester", auth_type="token", token="secret-token")
+    )
+
+    result = runner.invoke(auth, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "No credentials stored\n"
+
+
+def test_status_skips_configured_credentials_without_stored_record(mocker, runner, keyring):
+    """
+    Configured auth without an available secret is not reported as stored.
+    """
+    keyring(None)
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [
+        {"channel": "tester", "auth": "token", "auth_target": "tester"}
+    ]
+
+    result = runner.invoke(auth, ["status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {"success": True, "credentials": []}
+
+
+def test_status_explicit_target_matches_configured_auth_target(mocker, runner, keyring):
+    """
+    Explicit status can resolve records through a configured auth_target.
+    """
+    keyring(None)
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [
+        {
+            "channel": "https://example.com/private/*",
+            "auth": "token",
+            "auth_target": "https://example.com/private",
+        }
+    ]
+    KeyringStorage().set_credential(
+        CredentialRecord(
+            target="https://example.com/private",
+            auth_type="token",
+            username="token",
+            token="secret-token",
+        )
+    )
+
+    result = runner.invoke(auth, ["status", "https://example.com/private/osx-arm64"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "https://example.com/private: token\n"
+
+
+def test_status_targets_skip_invalid_settings(mocker):
+    """
+    Status ignores unrelated and malformed channel settings.
+    """
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [
+        None,
+        {"channel": "unconfigured"},
+        {"channel": 1, "auth": "token"},
+        {"channel": "tester", "auth": "token", "auth_target": 1},
+    ]
+
+    assert get_status_targets() == ("tester",)
+
+
+@pytest.mark.parametrize(
+    ("configured_channel", "channel_name", "expected"),
+    (
+        ("tester", "tester", True),
+        ("http://repo.example.com/*", "https://repo.example.com/private", False),
+        ("https://repo.example.com/*", "https://repo.example.com/private", True),
+        ("https://other.example.com/*", "https://repo.example.com/private", False),
+    ),
+    ids=("exact", "scheme-mismatch", "pattern-match", "pattern-mismatch"),
+)
+def test_status_channel_matching(configured_channel, channel_name, expected):
+    """
+    Status uses the same exact, scheme, and URL pattern matching as auth loading.
+    """
+    assert channel_matches(configured_channel, Channel(channel_name)) is expected
+
+
+def test_status_displays_credential_expiration(mocker, runner, keyring):
+    """
+    Text status includes an OAuth access token expiration time when available.
+    """
+    keyring(None)
+    mock_context = mocker.patch("conda_auth.cli.context")
+    mock_context.channel_settings = [
+        {"channel": "tester", "auth": "oauth2", "auth_target": "tester"}
+    ]
+    KeyringStorage().set_credential(
+        CredentialRecord(
+            target="tester",
+            auth_type="oauth2",
+            access_token="secret-token",
+            expires_at=3600,
+        )
+    )
+
+    result = runner.invoke(auth, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "tester: oauth2 expires_at=3600\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ class FakeRequest:
 @dataclass
 class RecordingKeyring:
     secret: str | None
+    secrets: dict[tuple[str, str], str] = field(default_factory=dict)
     get_password_calls: list[tuple[str, str]] = field(default_factory=list)
     set_password_calls: list[tuple[str, str, str]] = field(default_factory=list)
     delete_password_calls: list[tuple[str, str]] = field(default_factory=list)
@@ -46,17 +47,21 @@ class RecordingKeyring:
         self.get_password_calls.append((key_id, username))
         if self.get_password_side_effect is not None:
             raise self.get_password_side_effect
-        return self.secret
+        if key_id.startswith("conda-auth::credential::") or key_id == "conda-auth::index":
+            return self.secrets.get((key_id, username))
+        return self.secrets.get((key_id, username), self.secret)
 
     def set_password(self, key_id: str, username: str, password: str) -> None:
         self.set_password_calls.append((key_id, username, password))
         if self.set_password_side_effect is not None:
             raise self.set_password_side_effect
+        self.secrets[(key_id, username)] = password
 
     def delete_password(self, key_id: str, username: str) -> None:
         self.delete_password_calls.append((key_id, username))
         if self.delete_password_side_effect is not None:
             raise self.delete_password_side_effect
+        self.secrets.pop((key_id, username), None)
 
 
 @dataclass
@@ -137,7 +142,37 @@ def keyring(mocker):
     def _keyring(secret):
         get_keyring = mocker.patch("conda_auth.storage.get_keyring")
         keyring_storage = mocker.patch("conda_auth.storage.keyring.keyring")
-        keyring_storage.get_password.return_value = secret
+        keyring_storage.secrets = {}
+        keyring_storage.get_password_calls = []
+        keyring_storage.set_password_calls = []
+        keyring_storage.delete_password_calls = []
+        keyring_storage.get_password_side_effect = None
+        keyring_storage.set_password_side_effect = None
+        keyring_storage.delete_password_side_effect = None
+
+        def get_password(key_id, username):
+            keyring_storage.get_password_calls.append((key_id, username))
+            if keyring_storage.get_password_side_effect is not None:
+                raise keyring_storage.get_password_side_effect
+            if key_id.startswith("conda-auth::credential::") or key_id == "conda-auth::index":
+                return keyring_storage.secrets.get((key_id, username))
+            return keyring_storage.secrets.get((key_id, username), secret)
+
+        def set_password(key_id, username, password):
+            keyring_storage.set_password_calls.append((key_id, username, password))
+            if keyring_storage.set_password_side_effect is not None:
+                raise keyring_storage.set_password_side_effect
+            keyring_storage.secrets[(key_id, username)] = password
+
+        def delete_password(key_id, username):
+            keyring_storage.delete_password_calls.append((key_id, username))
+            if keyring_storage.delete_password_side_effect is not None:
+                raise keyring_storage.delete_password_side_effect
+            keyring_storage.secrets.pop((key_id, username), None)
+
+        keyring_storage.get_password.side_effect = get_password
+        keyring_storage.set_password.side_effect = set_password
+        keyring_storage.delete_password.side_effect = delete_password
 
         return keyring_storage, get_keyring
 

--- a/tests/handlers/test_base.py
+++ b/tests/handlers/test_base.py
@@ -4,13 +4,32 @@ import pytest
 from conda.models.channel import Channel
 
 from conda_auth.constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
+from conda_auth.credentials import CredentialRecord
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.handlers.base import (
+    AuthManager,
     allows_plaintext_http,
     get_url_host,
     is_loopback_host,
     validate_secure_channel,
 )
+
+
+class StubAuthManager(AuthManager):
+    def _fetch_secret(self, channel, settings):
+        raise NotImplementedError
+
+    def remove_secret(self, channel, settings):
+        raise NotImplementedError
+
+    def get_auth_type(self):
+        return "test"
+
+    def get_config_parameters(self):
+        return ()
+
+    def get_auth_class(self):
+        return object
 
 
 @pytest.mark.parametrize(
@@ -99,3 +118,33 @@ def test_is_loopback_host(host, expected):
 )
 def test_allows_plaintext_http(settings, expected):
     assert allows_plaintext_http(settings) is expected
+
+
+def test_auth_manager_builds_default_credential_record():
+    channel = Channel("tester")
+
+    record = StubAuthManager().create_credential_record(channel, "username", "password")
+
+    assert record == CredentialRecord(
+        target="tester",
+        auth_type="test",
+        username="username",
+        password="password",
+    )
+
+
+def test_auth_manager_returns_stored_credential_record(mocker):
+    channel = Channel("tester")
+    record = CredentialRecord(target="tester", auth_type="test")
+    mock_storage = mocker.patch("conda_auth.handlers.base.storage")
+    mock_storage.get_credential.return_value = record
+
+    assert StubAuthManager().get_credential_record(channel) == record
+
+
+def test_auth_manager_default_legacy_credential_behavior():
+    channel = Channel("tester")
+    auth_manager = StubAuthManager()
+
+    assert auth_manager.migrate_legacy_credential_record(channel, None, "tester") is None
+    assert auth_manager.legacy_credential_targets(channel, "shared") == ("shared", "tester")

--- a/tests/handlers/test_basic_auth.py
+++ b/tests/handlers/test_basic_auth.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock
 import pytest
 from conda.exceptions import CondaError
 from conda.models.channel import Channel
-from keyring.errors import PasswordDeleteError
 from requests.auth import HTTPBasicAuth
 
+from conda_auth.credentials import CredentialRecord
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.handlers.basic_auth import (
     HTTP_BASIC_AUTH_NAME,
@@ -81,6 +81,50 @@ def test_basic_auth_manager_rejects_non_string_credentials(keyring, settings, me
         manager.store(Channel("tester"), settings)
 
 
+def test_basic_auth_manager_uses_stored_username():
+    record = CredentialRecord(
+        target="tester",
+        auth_type=HTTP_BASIC_AUTH_NAME,
+        username="admin",
+        password="secret",
+    )
+
+    assert BasicAuthManager().get_username({}, record) == "admin"
+
+
+@pytest.mark.parametrize(
+    "settings",
+    (None, {USERNAME_PARAM_NAME: "admin"}),
+    ids=("missing-settings", "non-keyring-backend"),
+)
+def test_basic_auth_legacy_operations_require_keyring(mocker, settings):
+    mock_storage = mocker.patch("conda_auth.handlers.basic_auth.storage")
+    mock_storage.backend = object()
+    auth_manager = BasicAuthManager()
+    channel = Channel("tester")
+
+    assert auth_manager.migrate_legacy_credential_record(channel, settings, "tester") is None
+    auth_manager.delete_legacy_credential_record(channel, settings, "tester")
+
+
+def test_basic_auth_legacy_migration_uses_auth_target(keyring):
+    keyring_mock, _ = keyring(None)
+    keyring_mock.secrets[("conda-auth::http-basic::shared", "admin")] = "secret"
+
+    record = BasicAuthManager().migrate_legacy_credential_record(
+        Channel("tester"),
+        {USERNAME_PARAM_NAME: "admin"},
+        "shared",
+    )
+
+    assert record == CredentialRecord(
+        target="shared",
+        auth_type=HTTP_BASIC_AUTH_NAME,
+        username="admin",
+        password="secret",
+    )
+
+
 def test_basic_auth_manager_with_previous_secret(keyring):
     """
     Test to make sure when there is a password set, we retrieve it and set the
@@ -93,7 +137,7 @@ def test_basic_auth_manager_with_previous_secret(keyring):
     channel = Channel("tester")
 
     # setup mocks
-    keyring_mock, _ = keyring(secret)
+    keyring(secret)
 
     # run code under test
     manager.store(channel, settings)
@@ -101,7 +145,6 @@ def test_basic_auth_manager_with_previous_secret(keyring):
 
     # make assertions
     assert manager._cache == {channel.canonical_name: ("admin", secret)}
-    keyring_mock.get_password.assert_called_once()
 
 
 def test_basic_auth_manager_get_secret_cache_exists(keyring):
@@ -142,23 +185,27 @@ def test_basic_auth_manager_remove_existing_secret(keyring):
     manager.remove_secret(channel, settings)
 
     # make assertions
-    keyring_mock.delete_password.assert_called_once()
+    assert keyring_mock.delete_password_calls == [
+        ("conda-auth::credential::tester", "credential"),
+        ("conda-auth::http-basic::tester", "username"),
+    ]
 
 
 def test_basic_auth_manager_remove_existing_secret_no_username(keyring):
     """
-    Test to make sure that when removing a password that exist it fails when no username is present
+    Test that structured credentials can be removed without legacy username metadata.
     """
     secret = "secret"
     settings = {}
     channel = Channel("tester")
 
     # setup mocks
-    keyring(secret)
+    keyring_mock, _ = keyring(secret)
 
     # run code under test
-    with pytest.raises(CondaAuthError, match="Username not found"):
-        manager.remove_secret(channel, settings)
+    manager.remove_secret(channel, settings)
+
+    assert keyring_mock.delete_password_calls == [("conda-auth::credential::tester", "credential")]
 
 
 def test_basic_auth_manager_remove_non_existing_secret(keyring):
@@ -166,20 +213,18 @@ def test_basic_auth_manager_remove_non_existing_secret(keyring):
     Test make sure that when removing a secret that does not exist, the appropriate
     exception and message is raised and shown.
     """
-    secret = "secret"
     settings = {
         "username": "username",
     }
     channel = Channel("tester")
 
     # setup mocks
-    keyring_mock, _ = keyring(secret)
-    message = "Secret not found."
-    keyring_mock.delete_password.side_effect = PasswordDeleteError(message)
+    keyring_mock, _ = keyring(None)
+    keyring_mock.delete_password_side_effect = None
 
     # make assertions
-    with pytest.raises(CondaAuthError, match=f"Unable to remove secret: {message}"):
-        manager.remove_secret(channel, settings)
+    manager.remove_secret(channel, settings)
+    assert keyring_mock.delete_password_calls == [("conda-auth::credential::tester", "credential")]
 
 
 def test_basic_auth_handler(mocker, keyring):
@@ -210,8 +255,27 @@ def test_basic_auth_handler(mocker, keyring):
     HTTPBasicAuth(username, password)(expected_request)
 
     assert request.headers == expected_request.headers
-    keyring_mock.get_password.assert_called_once_with("conda-auth::http-basic::channel", username)
+    assert keyring_mock.get_password_calls == [
+        ("conda-auth::credential::channel", "credential"),
+        ("conda-auth::http-basic::channel", username),
+    ]
     keyring_mock.set_password.assert_not_called()
+
+
+def test_basic_auth_handler_preserves_existing_authorization(
+    monkeypatch,
+    context_factory,
+    request_factory,
+):
+    channel = Channel("tester")
+    manager._cache = {channel.canonical_name: ("username", "password")}
+    monkeypatch.setattr(manager, "_context", context_factory())
+    request = request_factory(headers={"Authorization": "Bearer existing"})
+
+    result = BasicAuthHandler(channel.canonical_name)(request)
+
+    assert result is request
+    assert request.headers == {"Authorization": "Bearer existing"}
 
 
 def test_basic_auth_handler_equals_methods(mocker, keyring):
@@ -268,7 +332,10 @@ def test_basic_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
     BasicAuthHandler(channel_name)
     BasicAuthHandler(channel_name)
 
-    keyring_mock.get_password.assert_called_once()
+    assert keyring_mock.get_password_calls == [
+        ("conda-auth::credential::channel", "credential"),
+        ("conda-auth::http-basic::channel", username),
+    ]
     keyring_mock.set_password.assert_not_called()
 
 
@@ -331,9 +398,10 @@ def test_basic_auth_handler_allows_plaintext_http_when_configured(
     HTTPBasicAuth(username, password)(expected_request)
 
     assert request.headers == expected_request.headers
-    keyring_mock.get_password.assert_called_once_with(
-        "conda-auth::http-basic::http://example.com/private-channel", username
-    )
+    assert keyring_mock.get_password_calls == [
+        ("conda-auth::credential::http://example.com/private-channel", "credential"),
+        ("conda-auth::http-basic::http://example.com/private-channel", username),
+    ]
     keyring_mock.set_password.assert_not_called()
 
 

--- a/tests/handlers/test_token.py
+++ b/tests/handlers/test_token.py
@@ -5,9 +5,9 @@ from unittest.mock import MagicMock
 import pytest
 from conda.exceptions import CondaError
 from conda.models.channel import Channel
-from keyring.errors import PasswordDeleteError
 
 from conda_auth.constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
+from conda_auth.credentials import CredentialRecord
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.handlers.token import (
     TOKEN_NAME,
@@ -94,6 +94,34 @@ def test_token_auth_manager_with_token(keyring, channel_name, settings):
     assert manager._cache == {channel.canonical_name: (USERNAME, token)}
 
 
+def test_token_legacy_operations_require_keyring(mocker):
+    mock_storage = mocker.patch("conda_auth.handlers.token.storage")
+    mock_storage.backend = object()
+    token_manager = TokenAuthManager()
+    channel = Channel("tester")
+
+    assert token_manager.migrate_legacy_credential_record(channel, None, "tester") is None
+    token_manager.delete_legacy_credential_record(channel, None, "tester")
+
+
+def test_token_legacy_migration_uses_auth_target(keyring):
+    keyring_mock, _ = keyring(None)
+    keyring_mock.secrets[("conda-auth::token::shared", USERNAME)] = "secret"
+
+    record = TokenAuthManager().migrate_legacy_credential_record(
+        Channel("tester"),
+        None,
+        "shared",
+    )
+
+    assert record == CredentialRecord(
+        target="shared",
+        auth_type=TOKEN_NAME,
+        username=USERNAME,
+        token="secret",
+    )
+
+
 def test_basic_auth_manager_remove_existing_secret(keyring):
     """
     Test to make sure that removing a password that exist works.
@@ -111,7 +139,10 @@ def test_basic_auth_manager_remove_existing_secret(keyring):
     manager.remove_secret(channel, settings)
 
     # make assertions
-    keyring_mock.delete_password.assert_called_once()
+    assert keyring_mock.delete_password_calls == [
+        ("conda-auth::credential::tester", "credential"),
+        ("conda-auth::token::tester", USERNAME),
+    ]
 
 
 def test_basic_auth_manager_remove_non_existing_secret(keyring):
@@ -119,20 +150,17 @@ def test_basic_auth_manager_remove_non_existing_secret(keyring):
     Test make sure that when removing a secret that does not exist, the appropriate
     exception and message is raised and shown.
     """
-    secret = "secret"
     settings = {
         "username": USERNAME,
     }
     channel = Channel("tester")
 
     # setup mocks
-    keyring_mock, _ = keyring(secret)
-    message = "Secret not found."
-    keyring_mock.delete_password.side_effect = PasswordDeleteError(message)
+    keyring_mock, _ = keyring(None)
 
     # make assertions
-    with pytest.raises(CondaAuthError, match=f"Unable to remove secret: {message}"):
-        manager.remove_secret(channel, settings)
+    manager.remove_secret(channel, settings)
+    assert keyring_mock.delete_password_calls == [("conda-auth::credential::tester", "credential")]
 
 
 def test_token_auth_handler_with_anaconda_dot_org_token(mocker, keyring):
@@ -158,7 +186,10 @@ def test_token_auth_handler_with_anaconda_dot_org_token(mocker, keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": f"token {token}"}
-    keyring_mock.get_password.assert_called_once()
+    assert keyring_mock.get_password_calls == [
+        ("conda-auth::credential::channel", "credential"),
+        ("conda-auth::token::channel", USERNAME),
+    ]
     keyring_mock.set_password.assert_not_called()
 
 
@@ -185,7 +216,10 @@ def test_token_auth_handler_with_bearer_token(mocker, keyring):
     request = auth_handler(request)
 
     assert request.headers == {"Authorization": f"Bearer {token}"}
-    keyring_mock.get_password.assert_called_once()
+    assert keyring_mock.get_password_calls == [
+        ("conda-auth::credential::http://localhost", "credential"),
+        ("conda-auth::token::http://localhost", USERNAME),
+    ]
     keyring_mock.set_password.assert_not_called()
 
 
@@ -205,7 +239,10 @@ def test_token_auth_handler_cache_reuses_keyring_secret(mocker, keyring):
     TokenAuthHandler(channel_name)
     TokenAuthHandler(channel_name)
 
-    keyring_mock.get_password.assert_called_once()
+    assert keyring_mock.get_password_calls == [
+        ("conda-auth::credential::http://localhost", "credential"),
+        ("conda-auth::token::http://localhost", USERNAME),
+    ]
     keyring_mock.set_password.assert_not_called()
 
 
@@ -254,9 +291,10 @@ def test_token_auth_handler_allows_plaintext_http_when_configured(
     request = auth_handler(request_factory())
 
     assert request.headers == {"Authorization": f"Bearer {token}"}
-    keyring_mock.get_password.assert_called_once_with(
-        "conda-auth::token::http://example.com/private-channel", USERNAME
-    )
+    assert keyring_mock.get_password_calls == [
+        ("conda-auth::credential::http://example.com/private-channel", "credential"),
+        ("conda-auth::token::http://example.com/private-channel", USERNAME),
+    ]
     keyring_mock.set_password.assert_not_called()
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,7 @@ def test_get_updated_channel_settings_preserves_existing_channel_settings():
             "channel": "tester",
             "ssl_verify": False,
             "auth": "http-basic",
+            "auth_target": "tester",
             "username": "username",
         },
         {"channel": "other", "auth": "token"},
@@ -50,6 +51,7 @@ def test_get_updated_channel_settings_updates_last_exact_channel():
             "channel": "tester",
             "ssl_verify": False,
             "auth": "http-basic",
+            "auth_target": "tester",
             "username": "username",
         },
     ]
@@ -70,6 +72,7 @@ def test_update_non_existing_condarc_file(tmp_path):
                 "channel": channel,
                 "username": username,
                 "auth": auth_type,
+                "auth_target": channel,
             }
         ]
     }
@@ -91,6 +94,7 @@ def test_update_existing_condarc_file(tmp_path):
                 "channel": channel,
                 "username": username,
                 "auth": auth_type,
+                "auth_target": channel,
             }
         ],
         "channels": ["defaults"],

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,52 @@
+import pytest
+
+from conda_auth.credentials import CredentialRecord
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_scopes", "expected_username", "expected_expires_at"),
+    (
+        (
+            {"scopes": ["channel:read", 1], "username": 123, "expires_at": 3600},
+            ("channel:read", "1"),
+            "123",
+            3600,
+        ),
+        (
+            {"scopes": ("channel:read", 1), "expires_at": "3600"},
+            ("channel:read", "1"),
+            None,
+            3600,
+        ),
+        (
+            {"scopes": "channel:read", "expires_at": "later"},
+            (),
+            None,
+            None,
+        ),
+        (
+            {"expires_at": []},
+            (),
+            None,
+            None,
+        ),
+    ),
+    ids=("list-values", "tuple-values", "invalid-strings", "invalid-type"),
+)
+def test_credential_record_from_dict_normalizes_values(
+    values,
+    expected_scopes,
+    expected_username,
+    expected_expires_at,
+):
+    record = CredentialRecord.from_dict(
+        {
+            "target": "tester",
+            "auth_type": "token",
+            **values,
+        }
+    )
+
+    assert record.scopes == expected_scopes
+    assert record.username == expected_username
+    assert record.expires_at == expected_expires_at

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,8 +1,18 @@
-import pytest
-from keyring.errors import NoKeyringError
+import os
+import subprocess
+import sys
 
+import pytest
+from keyring.errors import NoKeyringError, PasswordDeleteError
+
+from conda_auth.credentials import CredentialRecord
 from conda_auth.exceptions import CondaAuthError
 from conda_auth.storage import get_storage_backend
+from conda_auth.storage.keyring import (
+    KEYRING_CREDENTIAL_SERVICE_PREFIX,
+    KEYRING_CREDENTIAL_USERNAME,
+    KeyringStorage,
+)
 
 
 def test_no_available_storage_backend(keyring):
@@ -16,3 +26,142 @@ def test_no_available_storage_backend(keyring):
 
     with pytest.raises(CondaAuthError, match="Unable to find a credential storage backend"):
         get_storage_backend()
+
+
+def test_plugin_import_does_not_require_storage_backend():
+    """
+    Importing the conda plugin must not fail when credentials are not needed.
+    """
+    env = os.environ.copy()
+    env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.fail.Keyring"
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import conda_auth.plugin"],
+        capture_output=True,
+        env=env,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_keyring_storage_stores_structured_record(keyring):
+    """
+    Structured credentials are stored as one keyring item per target.
+    """
+    keyring_mock, _ = keyring(None)
+    backend = KeyringStorage()
+    record = CredentialRecord(
+        target="tester",
+        auth_type="token",
+        username="token",
+        token="secret-token",
+    )
+
+    backend.set_credential(record)
+
+    assert backend.get_credential("tester") == record
+    assert keyring_mock.secrets[
+        (
+            f"{KEYRING_CREDENTIAL_SERVICE_PREFIX}::tester",
+            KEYRING_CREDENTIAL_USERNAME,
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    (
+        ("{", "Unable to read stored credential"),
+        ("[]", "Stored credential for 'tester' is invalid"),
+    ),
+    ids=("malformed-json", "non-object-json"),
+)
+def test_keyring_storage_rejects_invalid_records(keyring, payload, message):
+    keyring_mock, _ = keyring(None)
+    keyring_mock.secrets[
+        (
+            f"{KEYRING_CREDENTIAL_SERVICE_PREFIX}::tester",
+            KEYRING_CREDENTIAL_USERNAME,
+        )
+    ] = payload
+
+    with pytest.raises(CondaAuthError, match=message):
+        KeyringStorage().get_credential("tester")
+
+
+def test_keyring_storage_deletes_structured_record(keyring):
+    """
+    Deleting a structured credential removes only that target record.
+    """
+    keyring(None)
+    backend = KeyringStorage()
+    backend.set_credential(CredentialRecord(target="tester", auth_type="token", token="secret"))
+
+    backend.delete_credential("tester")
+
+    assert backend.get_credential("tester") is None
+
+
+def test_keyring_storage_ignores_structured_delete_error(keyring):
+    keyring_mock, _ = keyring(None)
+    keyring_mock.delete_password_side_effect = PasswordDeleteError()
+
+    KeyringStorage().delete_credential("tester")
+
+    assert keyring_mock.delete_password_calls == [
+        (f"{KEYRING_CREDENTIAL_SERVICE_PREFIX}::tester", KEYRING_CREDENTIAL_USERNAME)
+    ]
+
+
+def test_keyring_storage_reads_legacy_password(keyring):
+    """
+    Old password-shaped entries can be read for one-time migration.
+    """
+    keyring_mock, _ = keyring(None)
+    backend = KeyringStorage()
+    keyring_mock.secrets[("conda-auth::token::tester", "token")] = "secret"
+
+    assert backend.get_legacy_password("token", "tester", "token") == "secret"
+
+
+def test_keyring_storage_deletes_legacy_password_when_present(keyring):
+    """
+    Legacy cleanup is best-effort and scoped to the old service name.
+    """
+    keyring_mock, _ = keyring(None)
+    backend = KeyringStorage()
+    keyring_mock.secrets[("conda-auth::token::tester", "token")] = "secret"
+
+    backend.delete_legacy_password("token", "tester", "token")
+
+    assert ("conda-auth::token::tester", "token") not in keyring_mock.secrets
+
+
+def test_keyring_storage_ignores_legacy_delete_error(keyring):
+    keyring_mock, _ = keyring("secret")
+    keyring_mock.delete_password_side_effect = PasswordDeleteError()
+
+    KeyringStorage().delete_legacy_password("token", "tester", "token")
+
+    assert keyring_mock.delete_password_calls == [("conda-auth::token::tester", "token")]
+
+
+def test_keyring_storage_delete_preserves_other_records(keyring):
+    """
+    Deleting one structured record does not require or mutate an index.
+    """
+    keyring(None)
+    backend = KeyringStorage()
+    backend.set_credential(CredentialRecord(target="one", auth_type="token", token="one"))
+    backend.set_credential(CredentialRecord(target="two", auth_type="token", token="two"))
+
+    backend.delete_credential("one")
+
+    assert backend.get_credential("one") is None
+    assert backend.get_credential("two") == CredentialRecord(
+        target="two",
+        auth_type="token",
+        token="two",
+    )


### PR DESCRIPTION
## Summary
- Stores structured credential records in keyring and derives redacted status output from configured auth targets.

## Review Order
This PR is the bottom open layer of native GitHub stack #72. PRs #57 and #58 have landed in `main`. Review this PR before #60.

## Chain Tracker
- Previous: #58 Harden auth transport handling
- Current: #59 Use structured credential storage and status
- Next: #60 Refactor auth CLI into package
- Status: ready for review

## Issues
- Closes #54