### PR TITLE
[11/19] Add OAuth2 endpoint authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A conda plugin for handling authenticated access to private channels.
 Conda auth currently supports the following types of authentication:
 
 - HTTP Basic Authentication
-- token authentication
+- bearer/header token authentication
+- OAuth 2.0/OIDC user login
 
 On top of this, conda auth supports session management via two subcommands for logging into services (`conda auth login`) and logging out of services (`conda auth logout`).
 
@@ -27,7 +28,15 @@ conda auth login https://example.com/my-protected-channel --basic
 **Log in** to an anaconda.org channel with a token:
 
 ```
-conda auth login my-private-channel --token
+conda auth login https://example.com/my-protected-channel --token
+```
+
+**Log in** to a channel with OAuth 2.0/OIDC:
+
+```
+conda auth login https://example.com/my-protected-channel --oauth2 \
+  --oauth-issuer-url https://idp.example.com \
+  --oauth-client-id my-client
 ```
 
 **Log out** of a channel to remove credentials from your computer:

--- a/conda_auth/cli/__init__.py
+++ b/conda_auth/cli/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from getpass import getpass
 from typing import Literal
 
@@ -14,17 +15,22 @@ from ..constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
 from ..exceptions import CondaAuthError
 from ..handlers import (
     HTTP_BASIC_AUTH_NAME,
+    OAUTH2_NAME,
     TOKEN_NAME,
     AuthManager,
     basic_auth_manager,
+    oauth2_auth_manager,
     token_auth_manager,
 )
 from ..handlers.base import allows_plaintext_http, validate_secure_channel
+from ..oauth2_client import perform_oauth_login, with_target
+from ..storage import storage
 from .config import (
     get_updated_channel_settings,
     remove_channel_settings,
     update_channel_settings,
 )
+from .oauth2 import build_oauth_login_config
 from .parser import PROMPT_VALUE, build_parser, configure_parser
 from .status import output_status
 from .status import status as get_status
@@ -32,6 +38,7 @@ from .status import status as get_status
 AUTH_MANAGER_MAPPING = {
     HTTP_BASIC_AUTH_NAME: basic_auth_manager,
     TOKEN_NAME: token_auth_manager,
+    OAUTH2_NAME: oauth2_auth_manager,
 }
 
 SUCCESSFUL_LOGIN_MESSAGE = "Successfully stored credentials"
@@ -80,6 +87,7 @@ def get_auth_manager(
     auth: str | None = None,
     basic: bool | None = None,
     token: str | Literal[False] | None = None,
+    oauth2: bool | None = None,
     **kwargs,
 ) -> tuple[str, AuthManager]:
     """
@@ -89,8 +97,10 @@ def get_auth_manager(
         pass
     elif basic:  # defined on CLI
         auth = HTTP_BASIC_AUTH_NAME
-    elif token:  # defined on CLI
+    elif token is not None:  # defined on CLI
         auth = TOKEN_NAME
+    elif oauth2:  # defined on CLI
+        auth = OAUTH2_NAME
     else:
         raise CondaAuthError("Missing authentication type.")
 
@@ -111,15 +121,24 @@ def login(channel: Channel, **kwargs):
     allow_plaintext_http = allows_plaintext_http(kwargs)
     channel_setting = channel.canonical_name
     credential_target = channel_setting
-    extra_params = {
-        param: kwargs.get(param)
-        for param in auth_manager.get_config_parameters()
-        if kwargs.get(param) is not None
-    }
-    extra_params["auth_target"] = credential_target
-    if allow_plaintext_http:
-        extra_params[AUTH_ALLOW_PLAINTEXT_HTTP_PARAM] = True
-    username, secret = auth_manager.fetch_secret(channel, extra_params, use_cache=False)
+    validate_secure_channel(channel, allow_plaintext_http=allow_plaintext_http)
+
+    record = None
+    username: str | None = None
+    secret: str | None = None
+    if auth_type == OAUTH2_NAME:
+        oauth_config = build_oauth_login_config(channel, kwargs)
+        record = with_target(perform_oauth_login(oauth_config), channel)
+    else:
+        extra_params = {
+            param: kwargs.get(param)
+            for param in auth_manager.get_config_parameters()
+            if kwargs.get(param) is not None
+        }
+        extra_params["auth_target"] = credential_target
+        if allow_plaintext_http:
+            extra_params[AUTH_ALLOW_PLAINTEXT_HTTP_PARAM] = True
+        username, secret = auth_manager.fetch_secret(channel, extra_params, use_cache=False)
 
     try:
         with ConfigurationFile.from_user_condarc() as config:
@@ -136,14 +155,17 @@ def login(channel: Channel, **kwargs):
         raise CondaAuthError(str(exc))
 
     try:
-        auth_manager.save_credentials(
-            channel,
-            username,
-            secret,
-            allow_plaintext_http=allow_plaintext_http,
-            target=credential_target,
-            settings=extra_params,
-        )
+        if record is not None:
+            storage.set_credential(record)
+        elif username is not None and secret is not None:
+            auth_manager.save_credentials(
+                channel,
+                username,
+                secret,
+                allow_plaintext_http=allow_plaintext_http,
+                target=credential_target,
+                settings=extra_params,
+            )
     except Exception as credential_error:
         auth_manager.cache_clear(channel.canonical_name)
         try:
@@ -199,14 +221,14 @@ def auth(args: argparse.Namespace) -> None:
     if args.command == "login":
         token = args.token
 
-        if not args.basic and token is None:
-            raise CondaAuthError("Missing option 'basic' / 'token'.")
+        if not args.basic and token is None and not args.oauth2:
+            raise CondaAuthError("Missing option 'basic' / 'token' / 'oauth2'.")
 
-        if token is not None:
+        if token is not None or args.oauth2:
             if args.username is not None:
-                raise CondaAuthError("Option 'username' cannot be used with 'token'")
+                raise CondaAuthError("Option 'username' cannot be used with 'token' or 'oauth2'")
             if args.password is not None:
-                raise CondaAuthError("Option 'password' cannot be used with 'token'")
+                raise CondaAuthError("Option 'password' cannot be used with 'token' or 'oauth2'")
 
         channel = Channel(args.channel)
         validate_secure_channel(
@@ -214,30 +236,45 @@ def auth(args: argparse.Namespace) -> None:
             allow_plaintext_http=args.allow_plaintext_http,
         )
 
-        if token is not None:
-            if token is PROMPT_VALUE:
-                token = prompt_secret("Token: ")
+        if token is PROMPT_VALUE:
+            token = prompt_secret("Token: ")
+
+        oauth_client_secret = args.oauth_client_secret
+        if oauth_client_secret is PROMPT_VALUE:
+            oauth_client_secret = prompt_secret("OAuth client secret: ")
+        oauth_output_stream = sys.stderr if args.json else None
+
+        if args.basic:
+            username = args.username
+            password = args.password
+
+            if username is None:
+                username = prompt_text("Username: ")
+            if password is None:
+                password = prompt_secret("Password: ")
+
             login(
                 channel,
-                token=token,
+                basic=True,
+                username=username,
+                password=password,
                 auth_allow_plaintext_http=args.allow_plaintext_http,
             )
             output_success(args, SUCCESSFUL_LOGIN_MESSAGE)
             return
 
-        username = args.username
-        password = args.password
-
-        if username is None:
-            username = prompt_text("Username: ")
-        if password is None:
-            password = prompt_secret("Password: ")
-
         login(
             channel,
-            basic=True,
-            username=username,
-            password=password,
+            token=token,
+            oauth2=args.oauth2,
+            oauth_issuer_url=args.oauth_issuer_url,
+            oauth_client_id=args.oauth_client_id,
+            oauth_client_secret=oauth_client_secret,
+            oauth_flow=args.oauth_flow,
+            oauth_scopes=args.oauth_scopes,
+            oauth_redirect_uri=args.oauth_redirect_uri,
+            user_agent=args.user_agent,
+            oauth_output_stream=oauth_output_stream,
             auth_allow_plaintext_http=args.allow_plaintext_http,
         )
         output_success(args, SUCCESSFUL_LOGIN_MESSAGE)

--- a/conda_auth/cli/config.py
+++ b/conda_auth/cli/config.py
@@ -6,6 +6,15 @@ from conda.cli.condarc import ConfigurationFile
 
 from ..constants import AUTH_ALLOW_PLAINTEXT_HTTP_PARAM
 from ..exceptions import CondaAuthError
+from ..oauth2_client import (
+    OAUTH_CLIENT_ID_PARAM_NAME,
+    OAUTH_CLIENT_SECRET_PARAM_NAME,
+    OAUTH_FLOW_PARAM_NAME,
+    OAUTH_ISSUER_URL_PARAM_NAME,
+    OAUTH_REDIRECT_URI_PARAM_NAME,
+    OAUTH_SCOPE_PARAM_NAME,
+    OAUTH_USER_AGENT_PARAM_NAME,
+)
 
 AUTH_CHANNEL_SETTING_KEYS = frozenset(
     (
@@ -14,6 +23,13 @@ AUTH_CHANNEL_SETTING_KEYS = frozenset(
         "username",
         "password",
         "token",
+        OAUTH_ISSUER_URL_PARAM_NAME,
+        OAUTH_CLIENT_ID_PARAM_NAME,
+        OAUTH_CLIENT_SECRET_PARAM_NAME,
+        OAUTH_FLOW_PARAM_NAME,
+        OAUTH_SCOPE_PARAM_NAME,
+        OAUTH_REDIRECT_URI_PARAM_NAME,
+        OAUTH_USER_AGENT_PARAM_NAME,
         AUTH_ALLOW_PLAINTEXT_HTTP_PARAM,
     )
 )

--- a/conda_auth/cli/oauth2.py
+++ b/conda_auth/cli/oauth2.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TextIO, cast
+
+from conda.models.channel import Channel
+
+from ..exceptions import CondaAuthError
+from ..oauth2_client import (
+    OAUTH_CLIENT_ID_PARAM_NAME,
+    OAUTH_CLIENT_SECRET_PARAM_NAME,
+    OAUTH_FLOW_PARAM_NAME,
+    OAUTH_ISSUER_URL_PARAM_NAME,
+    OAUTH_REDIRECT_URI_PARAM_NAME,
+    OAUTH_SCOPE_PARAM_NAME,
+    OAUTH_USER_AGENT_PARAM_NAME,
+    OAuthLoginConfig,
+    scopes_from_value,
+)
+
+
+def ensure_url_scheme(target: str) -> str:
+    """
+    Default bare OAuth issuer hosts to HTTPS.
+    """
+    if "://" in target:
+        return target
+    return f"https://{target}"
+
+
+def build_oauth_login_config(
+    channel: Channel,
+    options: Mapping[str, object],
+) -> OAuthLoginConfig:
+    """
+    Build an OAuth login configuration from parsed CLI options.
+    """
+    issuer_url = options.get(OAUTH_ISSUER_URL_PARAM_NAME)
+    client_id = options.get(OAUTH_CLIENT_ID_PARAM_NAME)
+    scopes = scopes_from_value(options.get(OAUTH_SCOPE_PARAM_NAME))
+
+    if issuer_url is None:
+        issuer_url = channel.base_url
+
+    if not isinstance(issuer_url, str):
+        raise CondaAuthError("OAuth issuer URL not found")
+    if not isinstance(client_id, str):
+        raise CondaAuthError("OAuth client ID not found")
+
+    flow = options.get(OAUTH_FLOW_PARAM_NAME) or "auto"
+    if not isinstance(flow, str):
+        raise CondaAuthError("OAuth flow must be text")
+
+    client_secret = options.get(OAUTH_CLIENT_SECRET_PARAM_NAME)
+    if client_secret is not None and not isinstance(client_secret, str):
+        raise CondaAuthError("OAuth client secret must be text")
+
+    redirect_uri = options.get(OAUTH_REDIRECT_URI_PARAM_NAME)
+    if redirect_uri is not None and not isinstance(redirect_uri, str):
+        raise CondaAuthError("OAuth redirect URI must be text")
+
+    user_agent = options.get(OAUTH_USER_AGENT_PARAM_NAME)
+    if user_agent is not None and not isinstance(user_agent, str):
+        raise CondaAuthError("OAuth user agent must be text")
+
+    output_stream_value = options.get("oauth_output_stream")
+    if output_stream_value is not None and not hasattr(output_stream_value, "write"):
+        raise CondaAuthError("OAuth output stream must be file-like")
+    output_stream = cast(TextIO | None, output_stream_value)
+
+    return OAuthLoginConfig(
+        issuer_url=ensure_url_scheme(issuer_url),
+        client_id=client_id,
+        client_secret=client_secret,
+        flow=flow,
+        scopes=scopes,
+        redirect_uri=redirect_uri,
+        user_agent=user_agent,
+        output_stream=output_stream,
+    )

--- a/conda_auth/cli/parser.py
+++ b/conda_auth/cli/parser.py
@@ -4,6 +4,8 @@ import argparse
 
 from conda.cli.helpers import add_parser_json
 
+from ..oauth2_client import OAUTH_SCOPE_PARAM_NAME
+
 PROMPT_VALUE = object()
 
 
@@ -26,6 +28,33 @@ def add_plaintext_option(parser: argparse.ArgumentParser) -> None:
         action="store_true",
         help="Allow credentials to be used over plaintext HTTP for this channel",
     )
+
+
+def add_oauth_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--oauth-issuer-url", help="OIDC issuer URL")
+    parser.add_argument("--oauth-client-id", help="OAuth client ID")
+    parser.add_argument(
+        "--oauth-client-secret",
+        nargs="?",
+        const=PROMPT_VALUE,
+        metavar="SECRET",
+        help="OAuth client secret for confidential clients",
+    )
+    parser.add_argument(
+        "--oauth-flow",
+        choices=("auto", "auth-code", "device-code"),
+        default="auto",
+        help="OAuth flow to use",
+    )
+    parser.add_argument(
+        "--oauth-scope",
+        dest=OAUTH_SCOPE_PARAM_NAME,
+        action="append",
+        default=[],
+        help="OAuth scope to request. May be supplied multiple times",
+    )
+    parser.add_argument("--oauth-redirect-uri", help="OAuth redirect URI")
+    parser.add_argument("--user-agent", help="User-Agent header for OAuth requests")
 
 
 def configure_parser(parser: argparse.ArgumentParser) -> None:
@@ -54,9 +83,15 @@ def configure_parser(parser: argparse.ArgumentParser) -> None:
         nargs="?",
         const=PROMPT_VALUE,
         metavar="TOKEN",
-        help="Token to use for private channels using an API token",
+        help="Bearer token to use in the Authorization header",
+    )
+    auth_options.add_argument(
+        "--oauth2",
+        action="store_true",
+        help="Use OAuth 2.0/OIDC authentication",
     )
     add_basic_options(login_parser)
+    add_oauth_options(login_parser)
     add_plaintext_option(login_parser)
     add_parser_json(login_parser)
     login_parser.set_defaults(parser=login_parser)

--- a/conda_auth/credentials.py
+++ b/conda_auth/credentials.py
@@ -49,6 +49,9 @@ class CredentialRecord:
     client_id: str | None = None
     """OAuth 2.0 client identifier used for refresh and revocation."""
 
+    client_secret: str | None = None
+    """OAuth 2.0 client secret used for refresh and revocation."""
+
     issuer_url: str | None = None
     """OAuth 2.0 issuer URL used for discovery and status output."""
 
@@ -79,6 +82,7 @@ class CredentialRecord:
             token_endpoint=_optional_str(data.get("token_endpoint")),
             revocation_endpoint=_optional_str(data.get("revocation_endpoint")),
             client_id=_optional_str(data.get("client_id")),
+            client_secret=_optional_str(data.get("client_secret")),
             issuer_url=_optional_str(data.get("issuer_url")),
             scopes=scopes,
         )
@@ -100,6 +104,7 @@ class CredentialRecord:
                 "token_endpoint": self.token_endpoint,
                 "revocation_endpoint": self.revocation_endpoint,
                 "client_id": self.client_id,
+                "client_secret": self.client_secret,
                 "issuer_url": self.issuer_url,
                 "scopes": list(self.scopes),
             }.items()

--- a/conda_auth/handlers/__init__.py
+++ b/conda_auth/handlers/__init__.py
@@ -7,6 +7,14 @@ from .basic_auth import (
 from .basic_auth import (
     manager as basic_auth_manager,
 )
+from .oauth2 import (
+    OAUTH2_NAME,
+    OAuth2AuthHandler,
+    OAuth2Manager,
+)
+from .oauth2 import (
+    manager as oauth2_auth_manager,
+)
 from .token import (
     TOKEN_NAME,
     TokenAuthHandler,
@@ -21,9 +29,13 @@ __all__ = [
     "BasicAuthHandler",
     "BasicAuthManager",
     "HTTP_BASIC_AUTH_NAME",
+    "OAUTH2_NAME",
+    "OAuth2AuthHandler",
+    "OAuth2Manager",
     "TOKEN_NAME",
     "TokenAuthHandler",
     "TokenAuthManager",
     "basic_auth_manager",
+    "oauth2_auth_manager",
     "token_auth_manager",
 ]

--- a/conda_auth/handlers/oauth2.py
+++ b/conda_auth/handlers/oauth2.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from conda.models.channel import Channel
+from conda.plugins.types import ChannelAuthBase
+
+from ..constants import PLUGIN_NAME
+from ..credentials import CredentialRecord
+from ..exceptions import CondaAuthError
+from ..oauth2_client import (
+    OAUTH2_NAME,
+    OAUTH2_USERNAME,
+    OAUTH_CLIENT_ID_PARAM_NAME,
+    OAUTH_CLIENT_SECRET_PARAM_NAME,
+    OAUTH_FLOW_PARAM_NAME,
+    OAUTH_ISSUER_URL_PARAM_NAME,
+    OAUTH_REDIRECT_URI_PARAM_NAME,
+    OAUTH_SCOPE_PARAM_NAME,
+    OAUTH_USER_AGENT_PARAM_NAME,
+    OAuthLoginConfig,
+    authorization_code_flow,
+    device_code_flow,
+    discover_oauth_metadata,
+    perform_oauth_login,
+    refresh_oauth_record,
+    revoke_oauth_record,
+    scopes_from_value,
+    with_target,
+)
+from .base import AuthManager
+
+__all__ = (
+    "OAUTH2_NAME",
+    "OAUTH_CLIENT_ID_PARAM_NAME",
+    "OAUTH_CLIENT_SECRET_PARAM_NAME",
+    "OAUTH_FLOW_PARAM_NAME",
+    "OAUTH_ISSUER_URL_PARAM_NAME",
+    "OAUTH_REDIRECT_URI_PARAM_NAME",
+    "OAUTH_SCOPE_PARAM_NAME",
+    "OAUTH_USER_AGENT_PARAM_NAME",
+    "OAuth2AuthHandler",
+    "OAuth2Manager",
+    "OAuthLoginConfig",
+    "authorization_code_flow",
+    "device_code_flow",
+    "discover_oauth_metadata",
+    "manager",
+    "perform_oauth_login",
+    "refresh_oauth_record",
+    "revoke_oauth_record",
+    "scopes_from_value",
+    "with_target",
+)
+
+
+class OAuth2Manager(AuthManager):
+    """Manage persisted OAuth 2.0 credentials for authenticated channels."""
+
+    def get_keyring_id(self, channel: Channel) -> str:
+        return f"{PLUGIN_NAME}::{OAUTH2_NAME}::{channel.canonical_name}"
+
+    def _fetch_secret(self, channel: Channel, settings: Mapping[str, object]) -> tuple[str, str]:
+        record = self.get_credential_record(channel, settings)
+        if record is None or record.auth_type != OAUTH2_NAME or record.access_token is None:
+            raise CondaAuthError("OAuth credential not found")
+
+        refreshed = refresh_oauth_record(record)
+        if refreshed.access_token is None:
+            raise CondaAuthError("OAuth credential not found")
+        if refreshed != record:
+            self.save_credential_record(refreshed)
+        self._cache[channel.canonical_name] = (OAUTH2_USERNAME, refreshed.access_token)
+        return OAUTH2_USERNAME, refreshed.access_token
+
+    def save_credential_record(self, record: CredentialRecord) -> None:
+        from ..storage import storage
+
+        storage.set_credential(record)
+
+    def remove_secret(self, channel: Channel, settings: Mapping[str, object]) -> None:
+        record = self.get_credential_record(channel, settings)
+        if record is not None:
+            revoke_oauth_record(record)
+        self.delete_credential_record(channel, settings)
+
+    def get_auth_type(self) -> str:
+        return OAUTH2_NAME
+
+    def get_config_parameters(self) -> tuple[str, ...]:
+        return (
+            OAUTH_ISSUER_URL_PARAM_NAME,
+            OAUTH_CLIENT_ID_PARAM_NAME,
+            OAUTH_CLIENT_SECRET_PARAM_NAME,
+            OAUTH_FLOW_PARAM_NAME,
+            OAUTH_SCOPE_PARAM_NAME,
+            OAUTH_REDIRECT_URI_PARAM_NAME,
+            OAUTH_USER_AGENT_PARAM_NAME,
+        )
+
+    def get_auth_class(self) -> type:
+        return OAuth2AuthHandler
+
+
+manager = OAuth2Manager()
+
+
+class OAuth2AuthHandler(ChannelAuthBase):
+    """Add a stored OAuth 2.0 bearer token to channel requests."""
+
+    def __init__(self, channel_name: str):
+        _, self.access_token = manager.get_secret(channel_name)
+        if self.access_token is None:
+            raise CondaAuthError(
+                f"Unable to find OAuth credential for requests with {channel_name}"
+            )
+        super().__init__(channel_name)
+
+    def __call__(self, r):
+        if "Authorization" not in r.headers:
+            r.headers["Authorization"] = f"Bearer {self.access_token}"
+        return r

--- a/conda_auth/oauth2_client.py
+++ b/conda_auth/oauth2_client.py
@@ -1,0 +1,622 @@
+"""
+OAuth 2.0/OIDC implementation for conda auth.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import time
+import webbrowser
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from ipaddress import ip_address
+from threading import Event, Thread
+from typing import TextIO
+from urllib.parse import parse_qs, urlsplit, urlunsplit
+
+import requests
+from conda.models.channel import Channel
+from requests.auth import HTTPBasicAuth
+
+from .credentials import CredentialRecord
+from .exceptions import CondaAuthError
+
+OAUTH2_NAME = "oauth2"
+OAUTH2_USERNAME = "oauth2"
+OAUTH_ISSUER_URL_PARAM_NAME = "oauth_issuer_url"
+OAUTH_CLIENT_ID_PARAM_NAME = "oauth_client_id"
+OAUTH_CLIENT_SECRET_PARAM_NAME = "oauth_client_secret"
+OAUTH_FLOW_PARAM_NAME = "oauth_flow"
+OAUTH_SCOPE_PARAM_NAME = "oauth_scopes"
+OAUTH_REDIRECT_URI_PARAM_NAME = "oauth_redirect_uri"
+OAUTH_USER_AGENT_PARAM_NAME = "user_agent"
+
+OAUTH_EXPIRY_SKEW_SECONDS = 300
+OAUTH_CALLBACK_TIMEOUT_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class OAuthLoginConfig:
+    """Configuration for an OAuth 2.0 user login."""
+
+    issuer_url: str
+    client_id: str
+    client_secret: str | None = None
+    flow: str = "auto"
+    scopes: tuple[str, ...] = ()
+    redirect_uri: str | None = None
+    user_agent: str | None = None
+    output_stream: TextIO | None = None
+
+    def __post_init__(self) -> None:
+        validate_oauth_endpoint_url(self.issuer_url, "issuer URL")
+
+
+@dataclass(frozen=True)
+class OAuthTokens:
+    """Token values returned by a successful OAuth 2.0 flow."""
+
+    access_token: str
+    refresh_token: str | None = None
+    expires_at: int | None = None
+    token_endpoint: str | None = None
+    revocation_endpoint: str | None = None
+
+
+class BrowserOpenError(CondaAuthError):
+    """Raised when the auth-code flow cannot open a browser."""
+
+
+@dataclass(frozen=True)
+class OAuthMetadata:
+    """OAuth 2.0 endpoints selected from provider discovery metadata."""
+
+    authorization_endpoint: str | None
+    token_endpoint: str | None
+    device_authorization_endpoint: str | None = None
+    revocation_endpoint: str | None = None
+
+    @classmethod
+    def from_mapping(cls, metadata: Mapping[str, object]) -> OAuthMetadata:
+        oauth_metadata = cls(
+            authorization_endpoint=cls.get_url(metadata, "authorization_endpoint"),
+            token_endpoint=cls.get_url(metadata, "token_endpoint"),
+            device_authorization_endpoint=cls.get_url(metadata, "device_authorization_endpoint"),
+            revocation_endpoint=cls.get_url(metadata, "revocation_endpoint"),
+        )
+        for key in (
+            "authorization_endpoint",
+            "token_endpoint",
+            "device_authorization_endpoint",
+            "revocation_endpoint",
+        ):
+            value = getattr(oauth_metadata, key)
+            if value is not None:
+                validate_oauth_endpoint_url(value, key)
+        return oauth_metadata
+
+    @staticmethod
+    def get_url(metadata: Mapping[str, object], key: str) -> str | None:
+        value = metadata.get(key)
+        if isinstance(value, str):
+            return value
+        return None
+
+    def require(self, key: str) -> str:
+        value = getattr(self, key)
+        if value is None:
+            raise CondaAuthError(f"OAuth discovery metadata did not include {key!r}")
+        return value
+
+
+@dataclass(frozen=True)
+class PKCEChallenge:
+    """PKCE verifier and S256 challenge for an authorization request."""
+
+    verifier: str
+    challenge: str
+
+    @classmethod
+    def create(cls) -> PKCEChallenge:
+        verifier = secrets.token_urlsafe(64)
+        digest = hashlib.sha256(verifier.encode()).digest()
+        challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+        return cls(verifier=verifier, challenge=challenge)
+
+
+class OAuthCallbackServer:
+    """Capture an OAuth authorization response on a loopback HTTP server."""
+
+    def __init__(self, redirect_uri: str | None, output_stream: TextIO | None = None) -> None:
+        self.output_stream = output_stream
+        if redirect_uri is None:
+            self.server = _CallbackServer(("127.0.0.1", 0), _CallbackHandler)
+            self.redirect_uri = f"http://127.0.0.1:{self.server.server_address[1]}/"
+            return
+
+        parsed_redirect = urlsplit(redirect_uri)
+        redirect_host = parsed_redirect.hostname
+        if (
+            parsed_redirect.scheme != "http"
+            or redirect_host not in {"127.0.0.1", "localhost"}
+            or parsed_redirect.port is None
+            or parsed_redirect.username is not None
+            or parsed_redirect.password is not None
+            or parsed_redirect.fragment
+        ):
+            raise CondaAuthError("OAuth redirect URI must use localhost with an explicit port")
+
+        self.server = _CallbackServer((redirect_host, parsed_redirect.port), _CallbackHandler)
+        self.redirect_uri = redirect_uri
+
+    def wait_for_authorization_response(self, authorization_url: str, expected_state: str) -> str:
+        """Open the authorization URL and wait for its validated callback."""
+
+        callback_state = _CallbackState(
+            expected_state=expected_state,
+            redirect_uri=self.redirect_uri,
+        )
+        self.server.callback_state = callback_state
+        thread = Thread(target=self.server.serve_forever, daemon=True)
+        thread.start()
+
+        try:
+            if not webbrowser.open(authorization_url):
+                raise BrowserOpenError("Unable to open browser for OAuth login")
+
+            print(f"Opening browser at:\n\n{authorization_url}", file=self.output_stream)
+            print("Waiting for authentication in browser...", file=self.output_stream)
+
+            if not callback_state.completed.wait(OAUTH_CALLBACK_TIMEOUT_SECONDS):
+                raise CondaAuthError("Timed out waiting for OAuth callback")
+        finally:
+            self.server.shutdown()
+            thread.join(timeout=5)
+            self.server.server_close()
+
+        if callback_state.error is not None:
+            raise CondaAuthError(callback_state.error)
+        if callback_state.authorization_response is None:
+            raise CondaAuthError("OAuth callback did not include an authorization response")
+        return callback_state.authorization_response
+
+
+class OAuthClient:
+    """Run OAuth 2.0 discovery, login, refresh, and revocation operations."""
+
+    def __init__(self, config: OAuthLoginConfig, metadata: Mapping[str, object]) -> None:
+        self.config = config
+        self.metadata = OAuthMetadata.from_mapping(metadata)
+
+    @classmethod
+    def discover(cls, config: OAuthLoginConfig) -> OAuthClient:
+        """Create a client from the issuer discovery document."""
+
+        return cls(config, cls.discover_metadata(config))
+
+    @staticmethod
+    def discover_metadata(config: OAuthLoginConfig) -> dict[str, object]:
+        """Fetch the issuer's OIDC discovery document."""
+
+        issuer_url = config.issuer_url.rstrip("/")
+        response = requests.get(
+            f"{issuer_url}/.well-known/openid-configuration",
+            headers=OAuthClient.headers(config.user_agent),
+            timeout=30,
+        )
+        response.raise_for_status()
+        metadata = response.json()
+        if not isinstance(metadata, dict):
+            raise CondaAuthError("OAuth discovery response is invalid")
+        return metadata
+
+    def login(self) -> CredentialRecord:
+        """Run the configured flow and return a credential record."""
+
+        if self.config.flow == "auth-code":
+            tokens = self.authorization_code_flow()
+        elif self.config.flow == "device-code":
+            tokens = self.device_code_flow()
+        elif self.config.flow == "auto":
+            try:
+                tokens = self.authorization_code_flow()
+            except BrowserOpenError:
+                tokens = self.device_code_flow()
+        else:
+            raise CondaAuthError("OAuth flow must be one of: auto, auth-code, device-code")
+
+        if tokens.token_endpoint is None:
+            raise CondaAuthError("OAuth token endpoint not found")
+
+        return CredentialRecord(
+            target="",
+            auth_type=OAUTH2_NAME,
+            username=OAUTH2_USERNAME,
+            access_token=tokens.access_token,
+            refresh_token=tokens.refresh_token,
+            expires_at=tokens.expires_at,
+            token_endpoint=tokens.token_endpoint,
+            revocation_endpoint=tokens.revocation_endpoint,
+            client_id=self.config.client_id,
+            client_secret=self.config.client_secret,
+            issuer_url=self.config.issuer_url,
+            scopes=self.config.scopes,
+        )
+
+    def authorization_code_flow(self) -> OAuthTokens:
+        """Run the authorization-code flow with PKCE."""
+
+        from authlib.integrations.requests_client import OAuth2Session
+
+        token_endpoint = self.metadata.require("token_endpoint")
+        callback = OAuthCallbackServer(self.config.redirect_uri, self.config.output_stream)
+        pkce = PKCEChallenge.create()
+        client = OAuth2Session(
+            self.config.client_id,
+            self.config.client_secret,
+            scope=" ".join(self.config.scopes),
+            redirect_uri=callback.redirect_uri,
+        )
+        authorization_url, state = client.create_authorization_url(
+            self.metadata.require("authorization_endpoint"),
+            code_challenge=pkce.challenge,
+            code_challenge_method="S256",
+        )
+        authorization_response = callback.wait_for_authorization_response(
+            authorization_url,
+            state,
+        )
+
+        token = client.fetch_token(
+            token_endpoint,
+            authorization_response=authorization_response,
+            code_verifier=pkce.verifier,
+            include_client_id=self.config.client_secret is None,
+        )
+        return self.tokens_from_response(
+            token,
+            token_endpoint,
+            self.metadata.revocation_endpoint,
+        )
+
+    def device_code_flow(self) -> OAuthTokens:
+        """Run the device authorization flow."""
+
+        device_endpoint = self.metadata.device_authorization_endpoint
+        if device_endpoint is None:
+            raise CondaAuthError("OAuth server does not support device-code flow")
+
+        token_endpoint = self.metadata.require("token_endpoint")
+        response = requests.post(
+            device_endpoint,
+            data={
+                "client_id": self.config.client_id,
+                "scope": " ".join(self.config.scopes),
+            },
+            headers=self.headers(self.config.user_agent),
+            timeout=30,
+        )
+        response.raise_for_status()
+        device_data = response.json()
+
+        verification_uri = device_data.get("verification_uri_complete") or device_data.get(
+            "verification_uri"
+        )
+        user_code = device_data.get("user_code")
+        if verification_uri is None:
+            raise CondaAuthError("OAuth device-code response did not include a verification URI")
+
+        print(
+            f"Open this URL to authenticate:\n\n{verification_uri}", file=self.config.output_stream
+        )
+        if user_code:
+            print(f"Enter code: {user_code}", file=self.config.output_stream)
+
+        device_code = device_data.get("device_code")
+        if not isinstance(device_code, str):
+            raise CondaAuthError("OAuth device-code response did not include a device code")
+
+        interval = int(device_data.get("interval", 5))
+        expires_in = int(device_data.get("expires_in", 900))
+        deadline = time.time() + expires_in
+
+        while time.time() < deadline:
+            time.sleep(interval)
+            token_response = requests.post(
+                token_endpoint,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    "device_code": device_code,
+                    "client_id": self.config.client_id,
+                },
+                headers=self.headers(self.config.user_agent),
+                timeout=30,
+            )
+            if token_response.status_code == 200:
+                return self.tokens_from_response(
+                    token_response.json(),
+                    token_endpoint,
+                    self.metadata.revocation_endpoint,
+                )
+
+            error = token_response.json().get("error")
+            if error == "authorization_pending":
+                continue
+            if error == "slow_down":
+                interval += 5
+                continue
+            raise CondaAuthError(f"OAuth device-code flow failed: {error or token_response.text}")
+
+        raise CondaAuthError("Timed out waiting for OAuth device authorization")
+
+    @staticmethod
+    def refresh_record(
+        record: CredentialRecord,
+        user_agent: str | None = None,
+    ) -> CredentialRecord:
+        """Refresh an OAuth credential that is near expiration."""
+
+        if record.auth_type != OAUTH2_NAME or record.expires_at is None:
+            return record
+        if record.expires_at - int(time.time()) >= OAUTH_EXPIRY_SKEW_SECONDS:
+            return record
+        if (
+            record.refresh_token is None
+            or record.token_endpoint is None
+            or record.client_id is None
+        ):
+            return record
+
+        validate_oauth_endpoint_url(record.token_endpoint, "token endpoint")
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": record.refresh_token,
+        }
+        auth = None
+        if record.client_secret is None and record.client_id is not None:
+            data["client_id"] = record.client_id
+        else:
+            auth = HTTPBasicAuth(record.client_id, record.client_secret)
+
+        response = requests.post(
+            record.token_endpoint,
+            data=data,
+            auth=auth,
+            headers=OAuthClient.headers(user_agent),
+            timeout=30,
+        )
+        if not response.ok:
+            return record
+
+        tokens = OAuthClient.tokens_from_response(
+            response.json(),
+            record.token_endpoint,
+            record.revocation_endpoint,
+        )
+        return CredentialRecord(
+            target=record.target,
+            auth_type=OAUTH2_NAME,
+            username=OAUTH2_USERNAME,
+            access_token=tokens.access_token,
+            refresh_token=tokens.refresh_token or record.refresh_token,
+            expires_at=tokens.expires_at,
+            token_endpoint=record.token_endpoint,
+            revocation_endpoint=record.revocation_endpoint,
+            client_id=record.client_id,
+            client_secret=record.client_secret,
+            issuer_url=record.issuer_url,
+            scopes=record.scopes,
+        )
+
+    @staticmethod
+    def revoke_record(record: CredentialRecord, user_agent: str | None = None) -> None:
+        """Best-effort revoke a stored OAuth credential."""
+
+        if record.revocation_endpoint is None:
+            return
+        token = record.refresh_token or record.access_token
+        if token is None:
+            return
+        try:
+            validate_oauth_endpoint_url(record.revocation_endpoint, "revocation endpoint")
+        except CondaAuthError:
+            return
+
+        data = {"token": token}
+        auth = None
+        client_id = record.client_id
+        if record.client_secret is None:
+            if client_id is not None:
+                data["client_id"] = client_id
+        elif client_id is not None:
+            auth = HTTPBasicAuth(client_id, record.client_secret)
+
+        try:
+            requests.post(
+                record.revocation_endpoint,
+                data=data,
+                auth=auth,
+                headers=OAuthClient.headers(user_agent),
+                timeout=30,
+            )
+        except requests.RequestException:
+            return
+
+    @staticmethod
+    def tokens_from_response(
+        data: Mapping[str, object],
+        token_endpoint: str,
+        revocation_endpoint: str | None,
+    ) -> OAuthTokens:
+        access_token = data.get("access_token")
+        if not isinstance(access_token, str):
+            raise CondaAuthError("OAuth token response did not include an access token")
+
+        expires_at = None
+        expires_in = data.get("expires_in")
+        if isinstance(expires_in, int):
+            expires_at = int(time.time()) + expires_in
+
+        refresh_token = data.get("refresh_token")
+        if not isinstance(refresh_token, str):
+            refresh_token = None
+
+        return OAuthTokens(
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at=expires_at,
+            token_endpoint=token_endpoint,
+            revocation_endpoint=revocation_endpoint,
+        )
+
+    @staticmethod
+    def headers(user_agent: str | None) -> dict[str, str] | None:
+        if user_agent is None:
+            return None
+        return {"User-Agent": user_agent}
+
+
+def discover_oauth_metadata(config: OAuthLoginConfig) -> dict[str, object]:
+    """Return OIDC discovery metadata for a login configuration."""
+
+    return OAuthClient.discover_metadata(config)
+
+
+def perform_oauth_login(config: OAuthLoginConfig) -> CredentialRecord:
+    """
+    Run the selected OAuth login flow and return a structured credential record.
+    """
+    return OAuthClient.discover(config).login()
+
+
+def authorization_code_flow(
+    config: OAuthLoginConfig,
+    metadata: Mapping[str, object],
+) -> OAuthTokens:
+    """
+    Run OAuth authorization-code flow with PKCE and a localhost callback.
+    """
+    return OAuthClient(config, metadata).authorization_code_flow()
+
+
+def device_code_flow(
+    config: OAuthLoginConfig,
+    metadata: Mapping[str, object],
+) -> OAuthTokens:
+    """
+    Run OAuth device authorization flow.
+    """
+    return OAuthClient(config, metadata).device_code_flow()
+
+
+def refresh_oauth_record(
+    record: CredentialRecord, user_agent: str | None = None
+) -> CredentialRecord:
+    """
+    Refresh an OAuth access token if it is expired or about to expire.
+    """
+    return OAuthClient.refresh_record(record, user_agent=user_agent)
+
+
+def revoke_oauth_record(record: CredentialRecord, user_agent: str | None = None) -> None:
+    """
+    Revoke OAuth tokens when the server exposes a revocation endpoint.
+    """
+    OAuthClient.revoke_record(record, user_agent=user_agent)
+
+
+def with_target(record: CredentialRecord, channel: Channel) -> CredentialRecord:
+    """Return a credential record scoped to a channel."""
+
+    return replace(record, target=channel.canonical_name)
+
+
+def validate_oauth_endpoint_url(url: str, label: str) -> None:
+    """Require HTTPS or loopback HTTP for an OAuth endpoint."""
+
+    parsed = urlsplit(url)
+    if parsed.scheme == "https" and parsed.netloc:
+        return
+    if parsed.scheme == "http" and is_loopback_host(parsed.hostname):
+        return
+    raise CondaAuthError(f"OAuth {label} must use HTTPS or loopback HTTP")
+
+
+def is_loopback_host(host: str | None) -> bool:
+    """Return whether a host identifies a loopback interface."""
+
+    if host is None:
+        return False
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+@dataclass
+class _CallbackState:
+    expected_state: str
+    redirect_uri: str
+    authorization_response: str | None = None
+    error: str | None = None
+    completed: Event = field(default_factory=Event)
+
+
+class _CallbackServer(HTTPServer):
+    callback_state: _CallbackState
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        server = self.server
+        assert isinstance(server, _CallbackServer)
+        state = server.callback_state
+        parsed = urlsplit(self.path)
+        query = parse_qs(parsed.query)
+        received_state = query.get("state", [None])[0]
+        redirect = urlsplit(state.redirect_uri)
+        expected_path = redirect.path or "/"
+        if parsed.path != expected_path:
+            state.error = "OAuth callback path did not match"
+        elif received_state != state.expected_state:
+            state.error = "OAuth callback state did not match"
+        elif "error" in query:
+            state.error = query["error"][0]
+        else:
+            state.authorization_response = urlunsplit(
+                (
+                    redirect.scheme,
+                    redirect.netloc,
+                    parsed.path,
+                    parsed.query,
+                    "",
+                )
+            )
+
+        body = b"Authentication complete. You can close this window."
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        state.completed.set()
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+def scopes_from_value(value: object) -> tuple[str, ...]:
+    """Normalize parsed OAuth scopes into a tuple."""
+
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if isinstance(value, Sequence):
+        return tuple(str(scope) for scope in value)
+    return ()

--- a/conda_auth/plugin.py
+++ b/conda_auth/plugin.py
@@ -28,10 +28,13 @@ def conda_auth_handlers():
     """
     from .handlers import (
         HTTP_BASIC_AUTH_NAME,
+        OAUTH2_NAME,
         TOKEN_NAME,
         BasicAuthHandler,
+        OAuth2AuthHandler,
         TokenAuthHandler,
     )
 
     yield CondaAuthHandler(name=HTTP_BASIC_AUTH_NAME, handler=BasicAuthHandler)
     yield CondaAuthHandler(name=TOKEN_NAME, handler=TokenAuthHandler)
+    yield CondaAuthHandler(name=OAUTH2_NAME, handler=OAuth2AuthHandler)

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,6 +48,14 @@ conda auth login example --token
 conda auth login https://example.com/my-protected-channel --token
 ```
 
+<h5>OAuth 2.0/OIDC authentication:</h5>
+
+```
+conda auth login https://example.com/my-protected-channel --oauth2 \
+  --oauth-issuer-url https://idp.example.com \
+  --oauth-client-id my-client
+```
+
 <h5>Removing credentials from your computer:</h5>
 
 ```

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -59,10 +59,58 @@ Passing tokens directly on the command line may expose them in shell history or 
 listings. Prefer the prompt-based command when working interactively.
 ```
 
-For other channels not hosted at anaconda.org, use the full URL of the channel:
+The request handler sends this as `Authorization: Bearer <token>` and does not
+overwrite an existing `Authorization` header.
+
+### OAuth 2.0/OIDC authentication
+
+OAuth 2.0 is available for OIDC services that support discovery plus
+authorization-code or device-code login flows:
 
 ```
-conda auth login https://example.com/my-protected-channel --token
+conda auth login https://repo.example.com --oauth2 \
+  --oauth-issuer-url https://idp.example.com \
+  --oauth-client-id my-client \
+  --oauth-flow auto
+```
+
+Supported OAuth 2.0 modes:
+
+- `auto`: tries browser authorization-code login first, and falls back to device-code
+  when the browser cannot be opened
+- `auth-code`: browser login with a localhost callback and PKCE
+- `device-code`: headless login for SSH and terminal-only environments
+
+Additional OAuth options include `--oauth-client-secret`, repeatable
+`--oauth-scope`, `--oauth-redirect-uri`, and `--user-agent`. conda-auth refreshes
+OAuth 2.0 access tokens before expiry when a refresh token is available, and
+attempts token revocation on logout when the OAuth server advertises a revocation
+endpoint.
+
+When supplied, the OAuth client secret is stored only in the credential record in
+the system keyring. It is not written to `channel_settings` in the condarc.
+
+The password grant, implicit flow, and client credentials grant are not supported.
+
+### Channel transports
+
+Conda auth supports authenticated HTTP(S) channel services. Remote channels must use
+HTTPS by default, and FTP and file channels are not supported by these auth handlers.
+
+Conda's `s3://` support currently uses boto3's normal AWS credential chain, such as
+environment variables, profiles, and instance credentials. Conda auth does not set
+process-wide AWS environment variables. First-class channel-scoped S3 credentials
+need a future conda-side S3 credential hook.
+
+For an explicitly trusted plaintext HTTP channel, opt in per channel:
+
+```
+conda auth login http://example.com/my-protected-channel --basic --allow-plaintext-http
+```
+
+```{caution}
+Plaintext HTTP sends credentials without transport encryption. Prefer HTTPS whenever
+possible, and only use `--allow-plaintext-http` for endpoints you explicitly trust.
 ```
 
 ### Logging out of a channel
@@ -83,6 +131,9 @@ Both `login` and `logout` support JSON output for automation:
 conda auth login <channel_name> --token --json
 conda auth logout <channel_name> --json
 ```
+
+`status` output is redacted and does not print stored tokens, passwords, OAuth 2.0
+access tokens, or refresh tokens.
 
 ### Storage backend unavailable?
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -85,6 +85,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.0.0-pyhd8ed1ab_0.conda
@@ -119,6 +120,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
@@ -156,6 +158,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.0.0-pyhd8ed1ab_0.conda
@@ -189,6 +192,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -228,6 +232,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.2-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py314hee6578b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.3.1-h0ba0a54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py314hd00f597_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py314h6482030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -281,6 +286,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.0.0-pyhd8ed1ab_0.conda
@@ -314,6 +320,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -353,6 +360,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.2-py314h4dc9dd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py314h4dc9dd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py314h0d331bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py314h0612a62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -406,6 +414,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.0.0-pyhd8ed1ab_0.conda
@@ -439,6 +448,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh7428d3b_0.conda
@@ -478,6 +488,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.2-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py314h86ab7b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py314he884d78_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozendict-2.4.7-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -613,6 +624,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
@@ -651,6 +663,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
@@ -697,6 +710,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
@@ -734,6 +748,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -783,6 +798,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py314hee6578b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.14.1-py314h77fa6c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.3.1-h0ba0a54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py314hd00f597_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py314h6482030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -842,6 +858,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
@@ -879,6 +896,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -928,6 +946,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py314h4dc9dd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.1-py314h6e9b3f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py314h0d331bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py314h0612a62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -987,6 +1006,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
@@ -1024,6 +1044,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh7428d3b_0.conda
@@ -1073,6 +1094,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py314h86ab7b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.14.1-py314h2359020_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py314he884d78_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozendict-2.4.7-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -1144,7 +1166,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-pypi-0.9.0-py310hff52083_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.4.4-py310h2372a71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cpp-expected-1.3.1-h171cf75_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py310h75e40e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-47.0.0-py310hb288b08_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.8.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
@@ -1218,6 +1240,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1252,6 +1275,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -1295,6 +1319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1328,6 +1353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -1374,6 +1400,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py310h2ec42d9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.4.4-py310hb372a2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.3.1-h0ba0a54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-47.0.0-py310h84da9b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py310hd2d5e8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -1435,6 +1462,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1468,6 +1496,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -1514,6 +1543,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py310hbe9552e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.4.4-py310hd125d64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-47.0.0-py310h12cab78_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py310hfe3a0ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -1575,6 +1605,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1608,6 +1639,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -1649,11 +1681,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py310h29418f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.2-py310h5588dad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py310h5588dad_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.4.4-py310h8d17308_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py310hff68572_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozendict-2.4.7-py310h29418f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py310h5588dad_3.conda
@@ -1722,12 +1755,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py311hb3a22ac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py311h03d9500_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-26.5.2-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-pypi-0.9.0-py311h38be061_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.4.4-py311h459d7ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cpp-expected-1.3.1-h171cf75_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py311h63ff55d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-49.0.0-py311h2005dd1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.8.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
@@ -1801,6 +1834,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1835,6 +1869,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -1878,6 +1913,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -1911,6 +1947,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -1952,11 +1989,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py311hc0b63fd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.1.0-py311hc34a7ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.2-py311h6eed73b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py311h6eed73b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.4.4-py311he705e18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.3.1-h0ba0a54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py311h60893eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py311hf197a57_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -2018,6 +2056,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2051,6 +2090,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -2092,11 +2132,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py311h4a08483_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.0-py311h833bfeb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.2-py311h267d04e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py311h267d04e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.4.4-py311h05b510d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py311hbb43c59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py311h9408147_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -2158,6 +2199,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2191,6 +2233,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -2232,11 +2275,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py311h3485c13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.2-py311h1ea47a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py311h1ea47a8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.4.4-py311ha68e1ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py311h2098ed6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozendict-2.4.7-py311h3485c13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py311h1ea47a8_3.conda
@@ -2305,12 +2349,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hd590300_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py312h460c074_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-26.5.2-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-pypi-0.9.0-py312h7900ff3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.4.4-py312h98912ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cpp-expected-1.3.1-h171cf75_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py312h241aef2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-49.0.0-py312ha4b625e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.8.1-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-12.1.0-hff5e90c_0.conda
@@ -2384,6 +2428,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2417,6 +2462,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.8.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -2460,6 +2506,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2492,6 +2539,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -2533,11 +2581,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h10d778d_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py312h38bf5a0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.1.0-py312h78829b9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.2-py312hb401068_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py312hb401068_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.4.4-py312h41838bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.3.1-h0ba0a54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py312h1af399d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py312h80b0991_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -2599,6 +2648,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2631,6 +2681,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -2672,11 +2723,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py312h8e38eb3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.0-py312h652e2b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.2-py312h81bd7bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py312h81bd7bf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.4.4-py312he37b823_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py312h1238841_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py312h4409184_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -2738,6 +2790,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -2770,6 +2823,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.classes-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyrings.alt-4.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.2.0-pyhd8ed1ab_0.conda
@@ -2811,11 +2865,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h53d5487_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py312he70551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py312he06e257_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.2-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py312h2e8e312_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.4.4-py312he70551f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py312h232196e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozendict-2.4.7-py312he06e257_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py312h2e8e312_3.conda
@@ -2958,6 +3013,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
@@ -2997,6 +3053,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
@@ -3044,6 +3101,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
@@ -3082,6 +3140,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -3132,6 +3191,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py313habf4b1d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.14.1-py313h035b7d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.3.1-h0ba0a54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py313ha8d32cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py313hf050af9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -3191,6 +3251,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
@@ -3229,6 +3290,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -3279,6 +3341,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py313h8f79df9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.1-py313h65a2061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py313hda5ae78_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py313h6535dbc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -3338,6 +3401,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
@@ -3376,6 +3440,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh7428d3b_0.conda
@@ -3425,6 +3490,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py313hfa70ccb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.14.1-py313hd650c13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py313hf5c5e30_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozendict-2.4.7-py313h5ea7bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -3563,6 +3629,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.5.0-py314h680f03e_0.conda
@@ -3603,6 +3670,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyha804496_0.conda
@@ -3650,6 +3718,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.5.0-py314h680f03e_0.conda
@@ -3689,6 +3758,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -3738,6 +3808,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-pypi-0.9.0-py314hee6578b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.14.1-py314h77fa6c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cpp-expected-1.3.1-h0ba0a54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py314hd00f597_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fmt-12.1.0-hda137b5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozendict-2.4.7-py314h6482030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
@@ -3797,6 +3868,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.5.0-py314h680f03e_0.conda
@@ -3836,6 +3908,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh534df25_0.conda
@@ -3885,6 +3958,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-pypi-0.9.0-py314h4dc9dd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.14.1-py314h6e9b3f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpp-expected-1.3.1-h4f10f1e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py314h0d331bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-12.1.0-h403dcb5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozendict-2.4.7-py314h0612a62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
@@ -3944,6 +4018,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.13.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/archspec-0.2.5-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.zstd-1.5.0-py314h680f03e_0.conda
@@ -3983,6 +4058,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.1.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.5.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpointer-3.1.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.7.0-pyh7428d3b_0.conda
@@ -4032,6 +4108,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/conda-pypi-0.9.0-py314h86ab7b2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.14.1-py314h2359020_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cpp-expected-1.3.1-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py314he884d78_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-12.1.0-h7f4e812_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozendict-2.4.7-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -4602,36 +4679,6 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 241339
   timestamp: 1696001848492
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py311hb3a22ac_0.conda
-  sha256: b71c94528ca0c35133da4b7ef69b51a0b55eeee570376057f3d2ad60c3ab1444
-  md5: b3469563ac5e808b0cd92810d0697043
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 300207
-  timestamp: 1696001873452
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
-  sha256: 5a36e2c254603c367d26378fa3a205bd92263e30acf195f488749562b4c44251
-  md5: 56b0ca764ce23cc54f3f7e2a7b970f6d
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - pycparser
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 294523
-  timestamp: 1696001868949
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py313hf46b229_1.conda
   sha256: 2162a91819945c826c6ef5efe379e88b1df0fe9a387eeba23ddcf7ebeacd5bd6
   md5: d0616e7935acab407d1543b28c446f6f
@@ -4664,6 +4711,38 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 300271
   timestamp: 1761203085220
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py311h03d9500_0.conda
+  sha256: 7c775ed3b4fae5ab0fbd6c7863538b85f7f66a715bb5d29badb2e91c58007cad
+  md5: 95f915485a5ce932a680b50926079064
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 309500
+  timestamp: 1783424169890
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.1.0-py312h460c074_0.conda
+  sha256: bdbc5810ea52e38b6b95e84826d818194ccfbe401a48c0d3829b8b7bb9093af5
+  md5: 0e336c897248bad80548df3414599254
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 302926
+  timestamp: 1783424167115
 - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-26.5.2-py310hff52083_0.conda
   sha256: 9733f2be326e77b2d3c545526a3b4ab5e7368795d7adc576c47a4346bba48c3e
   md5: 8b08babb3d18e4a4a90d18b687878f14
@@ -5047,51 +5126,26 @@ packages:
   purls: []
   size: 24283
   timestamp: 1756734785482
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py310h75e40e8_0.conda
-  sha256: eb514beb1c96969ebd299bb1979d6ccbf78087eb2a3772c364b94f778b8326ec
-  md5: 47e6ea7109182e9e48f8c5839f1bded7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-47.0.0-py310hb288b08_0.conda
+  sha256: ce9688209f0f7c6c67883d131e720e383efcda3d0e1e80e7ed2f5c6b8da8e370
+  md5: 0b07fd277c41e9a692c37c3bb2b02ce8
   depends:
-  - cffi >=1.12
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.14
+  - libgcc >=14
+  - openssl >=3.5.6,<4.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
+  - typing_extensions >=4.13.2
+  constrains:
+  - __glibc >=2.17
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
   - pkg:pypi/cryptography?source=hash-mapping
-  size: 1942507
-  timestamp: 1708780633068
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py311h63ff55d_0.conda
-  sha256: d3531a63f2bf9e234a8ebbbcef3dffc0721c8320166e3b86c05e05aef8c02480
-  md5: 76909c8c7b915f0af4f35e80da5f9a87
-  depends:
-  - cffi >=1.12
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
-  license_family: BSD
-  purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1992171
-  timestamp: 1708780569743
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py312h241aef2_0.conda
-  sha256: 5dc135fc6ea57bf94cf32313f91c93f8a4af15133879dd86e6c8c16e4e07c55e
-  md5: 0d8c0e4e8c1b2796eaf6770a76a9d1e4
-  depends:
-  - cffi >=1.12
-  - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
-  license_family: BSD
-  purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1976047
-  timestamp: 1708780611460
+  run_exports: {}
+  size: 1842311
+  timestamp: 1777106269891
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-48.0.0-py313heb322e3_0.conda
   sha256: 7c10cdde9f46d4b990e9c90ffb72bfb672b56d2ecae243d95582c9a9fc417ebf
   md5: 2310978ddde7f742d0b7a642d4894388
@@ -5128,6 +5182,44 @@ packages:
   - pkg:pypi/cryptography?source=hash-mapping
   size: 1926884
   timestamp: 1777966253398
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-49.0.0-py311h2005dd1_0.conda
+  sha256: 6117d70bc6e0a782d954ea2aecdbc72197707fbe7fe2868012867bf783f9d962
+  md5: 236fdbf560c1febba27a7c1380f2d257
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=2.0
+  - libgcc >=14
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1920225
+  timestamp: 1781385446857
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-49.0.0-py312ha4b625e_0.conda
+  sha256: c12e00af17f1507dbc186c9c663b44ca58b9b2209f59506be05547bd730346e5
+  md5: 46142c21318ee17d5beecf0de1fc5d47
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=2.0
+  - libgcc >=14
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1912490
+  timestamp: 1781385597345
 - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
   sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
   md5: ecfff944ba3960ecb334b9a2663d708d
@@ -7345,6 +7437,21 @@ packages:
   - pkg:pypi/archspec?source=hash-mapping
   size: 50894
   timestamp: 1737352715041
+- conda: https://conda.anaconda.org/conda-forge/noarch/authlib-1.7.2-pyhcf101f3_1.conda
+  sha256: b09b9310649b9c5e2983232f844c41861bfc48dbe91eaf6799f08c4b1ef03c88
+  md5: d9116c9ac1a8220ba314049a084a07ab
+  depends:
+  - cryptography
+  - joserfc >=1.6.0
+  - python >=3.10
+  - python
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/authlib?source=hash-mapping
+  run_exports: {}
+  size: 235228
+  timestamp: 1779157176427
 - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.18.0-pyhcf101f3_1.conda
   sha256: a14a9ad02101aab25570543a59c5193043b73dc311a25650134ed9e6cb691770
   md5: f1976ce927373500cc19d3c0b2c85177
@@ -8239,6 +8346,19 @@ packages:
   - pkg:pypi/jinja2?source=hash-mapping
   size: 120685
   timestamp: 1764517220861
+- conda: https://conda.anaconda.org/conda-forge/noarch/joserfc-1.7.2-pyhd8ed1ab_0.conda
+  sha256: 183667c1cd47fdab06aa9298c994d41cf65f693052e2efbdf692beb9362ffed0
+  md5: 318f86408e1f0362ed85bfdcbd5e3606
+  depends:
+  - cryptography >=45.0.1
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/joserfc?source=hash-mapping
+  run_exports: {}
+  size: 53884
+  timestamp: 1782740148755
 - conda: https://conda.anaconda.org/conda-forge/noarch/jsonpatch-1.33-pyhd8ed1ab_0.conda
   subdir: linux-64
   sha256: fbb17e33ace3225c6416d1604637c1058906b8223da968cc015128985336b2b4
@@ -9735,34 +9855,6 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 229407
   timestamp: 1696002017767
-- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py311hc0b63fd_0.conda
-  sha256: 1f13a5fa7f310fdbd27f5eddceb9e62cfb10012c58a58c923dd6f51fa979748a
-  md5: 15d07b82223cac96af629e5e747ba27a
-  depends:
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 289932
-  timestamp: 1696002096156
-- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py312h38bf5a0_0.conda
-  sha256: 8b856583b56fc30f064a7cb286f85e4b5725f2bd4fda8ba0c4e94bffe258741e
-  md5: a45759c013ab20b9017ef9539d234dd7
-  depends:
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 282370
-  timestamp: 1696002004433
 - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.0.0-py313hf57695f_1.conda
   sha256: 16c8c80bebe1c3d671382a64beaa16996e632f5b75963379e2b084eb6bc02053
   md5: b10f64f2e725afc9bf2d9b30eff6d0ea
@@ -9793,6 +9885,36 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 293633
   timestamp: 1761203106369
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.1.0-py311hc34a7ac_0.conda
+  sha256: 822c327e635b8ab16122967a85f67b43f3b49958c2acaffec0593dc7d41ad8c1
+  md5: 96c7ed5fac11001cdfd1d996eb8fa03a
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 300498
+  timestamp: 1783424543956
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-2.1.0-py312h78829b9_0.conda
+  sha256: 6384cb14d3f5dac0480712aa10b339fba9e5670aabe4b227c920664624eca8ed
+  md5: 178f92ea817283c0fdc84910f1c46709
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 293860
+  timestamp: 1783424550074
 - conda: https://conda.anaconda.org/conda-forge/osx-64/conda-26.5.2-py310h2ec42d9_0.conda
   sha256: 30c3bb7a7f781e2b95a61169a8660c53fce89899483d4f509f550fdfe14c16af
   md5: 2630d64a3d4171c89cb2f9c7fd644148
@@ -10170,6 +10292,97 @@ packages:
   purls: []
   size: 24618
   timestamp: 1756734941438
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-47.0.0-py310h84da9b3_0.conda
+  sha256: b43d32cf0e0028bc2d46bd14688166fa0f6476313f45ab88d4d0cbca15538b4a
+  md5: a5ffd049af232123d2a84372a9b08b3a
+  depends:
+  - __osx >=11.0
+  - cffi >=1.14
+  - openssl >=3.5.6,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - typing_extensions >=4.13.2
+  constrains:
+  - __osx >=10.13
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1781989
+  timestamp: 1777106664933
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py311h60893eb_0.conda
+  sha256: 383b511b354998a4efb4da4041aab9f374da32252cbf07107720dbe1d2aefd1d
+  md5: 4ce7956185aba728d33d88f6c6213447
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1836357
+  timestamp: 1781385753638
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py312h1af399d_0.conda
+  sha256: 692b58dbe64570f3a71ae5b2efa3d39ebebfd41d6a03952eae872398d09f4634
+  md5: 8ac30cac81d2121ddf103ce1657af12b
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1850790
+  timestamp: 1781385947222
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py313ha8d32cc_0.conda
+  sha256: 7e7fe894560ae9f588d781f076e8f2017c8ff6f7c737197e7b03c763b4377245
+  md5: a4d2dc857ef7c755b0a2534705108d6e
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1853759
+  timestamp: 1781385846284
+- conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-49.0.0-py314hd00f597_0.conda
+  sha256: 2eb1805843e65f6057c312edfbef0dab474ff9a12ff93c57f9f9d080b8343f49
+  md5: ed0cd98452f63f438194881426a39028
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1867418
+  timestamp: 1781385772375
 - conda: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.18.1-py312hb401068_1.conda
   sha256: 2af045a5ba0b61e77d849c5dca966a7f453eaa26c58d14e5127b95e535adeb07
   md5: 0d62b036556079c60714f0c6ea988302
@@ -12055,36 +12268,6 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 232227
   timestamp: 1696002085787
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py311h4a08483_0.conda
-  sha256: 9430416328fe2a28e206e703de771817064c8613a79a6a21fe7107f6a783104c
-  md5: cbdde0484a47b40e6ce2a4e5aaeb48d7
-  depends:
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 292511
-  timestamp: 1696002194472
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py312h8e38eb3_0.conda
-  sha256: 1544403cb1a5ca2aeabf0dac86d9ce6066d6fb4363493643b33ffd1b78038d18
-  md5: 960ecbd65860d3b1de5e30373e1bffb1
-  depends:
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.12.0rc3,<3.13.0a0
-  - python >=3.12.0rc3,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 284245
-  timestamp: 1696002181644
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.0.0-py313h224173a_1.conda
   sha256: 1fa69651f5e81c25d48ac42064db825ed1a3e53039629db69f86b952f5ce603c
   md5: 050374657d1c7a4f2ea443c0d0cbd9a0
@@ -12117,6 +12300,38 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 292983
   timestamp: 1761203354051
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.0-py311h833bfeb_0.conda
+  sha256: fa96675649d057baaf2ad4fc73f836781a58d0e3270f4776a3f4ee457bacda37
+  md5: eda60fa2b167c49a1b033450b4af6032
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 298491
+  timestamp: 1783424587732
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-2.1.0-py312h652e2b1_0.conda
+  sha256: c71742a1e7edb69faa9e0263c38456c61f0a371906e49988006042975a6f6a02
+  md5: aa86ced9f5d10592ebdccec40bce7370
+  depends:
+  - __osx >=11.0
+  - libffi >=3.5.2,<3.6.0a0
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 293461
+  timestamp: 1783424949768
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/conda-26.5.2-py310hbe9552e_0.conda
   sha256: 2558b2374431e71882c4d5fee42428bc18cb08f745f29fd2864cbc8fe730a8f9
   md5: 7f10445f1c8a8f4bafa55723f74eb74e
@@ -12509,6 +12724,98 @@ packages:
   purls: []
   size: 24960
   timestamp: 1756734870487
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-47.0.0-py310h12cab78_0.conda
+  sha256: b410e32eccfd536ad6469e8c087a1750badbf4137cdc6adf9d7515db10ab538e
+  md5: b9f4dc8a4e3304d39b82467bb1227fb2
+  depends:
+  - __osx >=11.0
+  - cffi >=1.14
+  - openssl >=3.5.6,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  - typing_extensions >=4.13.2
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1783453
+  timestamp: 1777106662091
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py311hbb43c59_0.conda
+  sha256: 4cc0c5c1d7e274c35ab73813fb40b614fa12263ee26ac499a1e2f65e00783f63
+  md5: ef82f0633add68a5c0c022920a39eb83
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1865966
+  timestamp: 1781385460486
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py312h1238841_0.conda
+  sha256: 50af482c90ac5decda27265ef20a1c2399b18d35c0378eecc90539b5a76ff85f
+  md5: 8269bb6adc80e76fd9f7bf4ee8ded3b8
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1852608
+  timestamp: 1781385456338
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py313hda5ae78_0.conda
+  sha256: aa94e10d98ce59815319fd7ef35be3b847778a5e9a164ee9663314ece832caaa
+  md5: fcafa4ea64298701d582b0bd697592be
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1856555
+  timestamp: 1781385454803
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-49.0.0-py314h0d331bb_0.conda
+  sha256: 095f69075f4b54bf4d3674f7a529926a4e9bc9c1452093135d3fdbef233a4783
+  md5: 8eb2d079cb2d42f28bc85c73977d05de
+  depends:
+  - __osx >=11.0
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  constrains:
+  - __osx >=11.0
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1871987
+  timestamp: 1781385445880
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.18.1-py312h81bd7bf_1.conda
   sha256: 3fa1d6cd13fce9b0090a2aa773382e52557798e2225d1a7775e7dcd613264a5c
   md5: d5f24b24be3fc8bc1b29396e0fcfa43a
@@ -14453,54 +14760,6 @@ packages:
   purls: []
   size: 155886
   timestamp: 1706843918052
-- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
-  sha256: 1aeebb88518ab48c927d7360648a2799def172d8fcb0d7e20cb7208a3570ef9e
-  md5: b4bcce1a7ea1164e6dcea6c4f00d962b
-  depends:
-  - pycparser
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 237888
-  timestamp: 1696002116250
-- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
-  sha256: eb7463fe3785dd9ac0b3b1e5fea3b721d20eb082e194cab0af8d9ff28c28934f
-  md5: d109d6e767c4890ea32880b8bfa4a3b6
-  depends:
-  - pycparser
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 297043
-  timestamp: 1696002186279
-- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py312he70551f_0.conda
-  sha256: dd39e594f5c6bca52dfed343de2af9326a99700ce2ba3404bd89706926fc0137
-  md5: 5a51096925d52332c62bfd8904899055
-  depends:
-  - pycparser
-  - python >=3.12.0rc3,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/cffi?source=hash-mapping
-  size: 287805
-  timestamp: 1696002408940
 - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.0.0-py313h5ea7bf4_1.conda
   sha256: f867a11f42bb64a09b232e3decf10f8a8fe5194d7e3a216c6bac9f40483bd1c6
   md5: 55b44664f66a2caf584d72196aa98af9
@@ -14533,6 +14792,54 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 294731
   timestamp: 1761203441365
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py310h29418f3_0.conda
+  sha256: 34715909a4d456c830e0f1b14c4b24933eff1dcf6e727f2618122e1d910db30e
+  md5: 0349458f87e869baef8eb0361b63efca
+  depends:
+  - pycparser
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 292254
+  timestamp: 1783424284624
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py311h3485c13_0.conda
+  sha256: 2678d367277f063cea235be77cc9e950354fa6dfe4d57326840a90d11665aef2
+  md5: bcec9706d41771c6df9cf29ca7ae873b
+  depends:
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 352297
+  timestamp: 1783424271538
+- conda: https://conda.anaconda.org/conda-forge/win-64/cffi-2.1.0-py312he06e257_0.conda
+  sha256: de3d6315389ed26a62a4130a3022350e6d9a21b117128227ce0a83d158a56c39
+  md5: 2421fbb9ae81fff1769994ede64f4ac4
+  depends:
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  purls:
+  - pkg:pypi/cffi?source=compressed-mapping
+  run_exports: {}
+  size: 344466
+  timestamp: 1783424278847
 - conda: https://conda.anaconda.org/conda-forge/win-64/conda-26.5.2-py310h5588dad_0.conda
   sha256: 9f09b88f341233f1b0be313e439fdd8e6d4959637cd7edbd3ec6591b5737b2ea
   md5: 6a0c5c076d065ffe918eab2c23c212f6
@@ -14927,6 +15234,97 @@ packages:
   purls: []
   size: 21733
   timestamp: 1756734797622
+- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py310hff68572_0.conda
+  sha256: 80d5704a65dd25d317899d783ae59ef2719de221598fecd1dfe7f1486b256e27
+  md5: a06d1780dfc3deefb82a3136ce3ab7b7
+  depends:
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - typing_extensions >=4.13.2
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1595169
+  timestamp: 1781385612173
+- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py311h2098ed6_0.conda
+  sha256: 592f3228fecd178e83c5f4c289923a7c5f6b5b005e2bc15cdb643838ca3f5b77
+  md5: fd8965ef0199472cafbf6ad497c1aa46
+  depends:
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1655254
+  timestamp: 1781385584350
+- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py312h232196e_0.conda
+  sha256: e55976b9c9f94346e4503b75b150b6d3d47d7945374497df86380fd08a5eb078
+  md5: 0924772e0c4173dd40c20a2e744dede4
+  depends:
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1644715
+  timestamp: 1781385605468
+- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py313hf5c5e30_0.conda
+  sha256: 2d255cc17d0a960a49678b0d5b8988b1a47837e91e3e009d4a19527e0ca6c198
+  md5: f44f6ceaa7d02fe9736af0f514796f79
+  depends:
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.13,<3.14.0a0
+  - python_abi 3.13.* *_cp313
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1647632
+  timestamp: 1781385579985
+- conda: https://conda.anaconda.org/conda-forge/win-64/cryptography-49.0.0-py314he884d78_0.conda
+  sha256: 7348f37f03538c7755824a39f33f6f30312e3349cd7b0a8b285a0bc377ba159e
+  md5: d8cfad425d09c7838d724f6c9501a1c4
+  depends:
+  - cffi >=2.0
+  - openssl >=3.5.7,<4.0a0
+  - python >=3.14,<3.15.0a0
+  - python_abi 3.14.* *_cp314
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  run_exports: {}
+  size: 1662747
+  timestamp: 1781385594371
 - conda: https://conda.anaconda.org/conda-forge/win-64/docutils-0.18.1-py312h2e8e312_1.conda
   sha256: 517fe814fbfe570978369bc6dd9f951739293cf90905213204f30b2c29df7946
   md5: 766c498c3e50dac8e4605d6ac9dcf5a8
@@ -16927,6 +17325,7 @@ packages:
 - pypi: .
   name: conda-auth
   requires_dist:
+  - authlib>=1.7.2
   - conda>=26.1
   - keyring
   - requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy"
 ]
 dependencies = [
+  "authlib>=1.7.2",
   "conda>=26.1",
   "keyring",
   "requests",
@@ -56,6 +57,7 @@ build = "rattler-build build --recipe recipe.yaml"
 
 [tool.pixi.dependencies]
 python = ">=3.10"
+authlib = ">=1.7.2"
 conda = ">=26.1"
 keyring = "*"
 requests = "*"

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -24,6 +24,7 @@ requirements:
     - hatch-vcs
   run:
     - python >=3.10,<4.0.0
+    - authlib >=1.7.2
     - conda >=26.1
     - keyring
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - hatch-vcs
   run:
     - python >=3.10,<4.0.0
+    - authlib >=1.7.2
     - conda >=26.1
     - keyring
     - requests

--- a/tests/cli/test_login.py
+++ b/tests/cli/test_login.py
@@ -4,7 +4,9 @@ import pytest
 from conda.exceptions import CondaError
 
 from conda_auth.cli import SUCCESSFUL_LOGIN_MESSAGE, auth
+from conda_auth.credentials import CredentialRecord
 from conda_auth.exceptions import CondaAuthError
+from conda_auth.storage import storage
 
 
 def test_login_basic_auth_no_options(mocker, runner, keyring, condarc):
@@ -49,15 +51,21 @@ def test_login_with_options_basic_auth(runner, keyring, condarc):
 @pytest.mark.parametrize(
     ("args", "message"),
     (
-        (["login", "tester"], "Missing option 'basic' / 'token'."),
-        (["login", "tester", "--json"], "Missing option 'basic' / 'token'."),
+        (
+            ["login", "tester"],
+            "Missing option 'basic' / 'token' / 'oauth2'.",
+        ),
+        (
+            ["login", "tester", "--json"],
+            "Missing option 'basic' / 'token' / 'oauth2'.",
+        ),
         (
             ["login", "tester", "--token", "token", "--username", "user", "--json"],
-            "Option 'username' cannot be used with 'token'",
+            "Option 'username' cannot be used with 'token' or 'oauth2'",
         ),
         (
             ["login", "tester", "--token", "token", "--password", "password", "--json"],
-            "Option 'password' cannot be used with 'token'",
+            "Option 'password' cannot be used with 'token' or 'oauth2'",
         ),
     ),
     ids=("missing-auth", "missing-auth-json", "token-username-json", "token-password-json"),
@@ -171,17 +179,16 @@ def test_login_allows_plaintext_http_when_explicit(
     """
     Persists explicit plaintext HTTP opt-in with the channel auth settings.
     """
-    keyring_mock, _ = keyring(None)
+    keyring(None)
 
     result = runner.invoke(auth, args)
 
     assert result.exit_code == 0, result.output
     assert condarc.content == {"channel_settings": [expected_settings]}
-    keyring_mock.set_password.assert_called_once()
-    key, username, payload = keyring_mock.set_password_calls[0]
-    assert key == "conda-auth::credential::http://example.com/private-channel"
-    assert username == "credential"
-    assert json.loads(payload) == expected_record
+    target = expected_settings["channel"]
+    stored_record = storage.get_credential(target)
+    assert stored_record is not None
+    assert stored_record.to_dict() | expected_record == stored_record.to_dict()
 
 
 def test_login_error_when_updating_condarc_does_not_store_secret(runner, keyring, condarc):
@@ -299,7 +306,45 @@ def test_login_token_json(runner, keyring, condarc):
     }
 
 
-def test_login_token_no_options(mocker, runner, keyring, condarc):
+def test_login_oauth_json_routes_interactive_output_to_stderr(
+    monkeypatch, runner, keyring, condarc
+):
+    keyring(None)
+
+    def perform_oauth_login(config):
+        print("Open this URL to authenticate", file=config.output_stream)
+        return CredentialRecord(
+            target="",
+            auth_type="oauth2",
+            username="oauth2",
+            access_token="access-token",
+            token_endpoint="https://repo.example.com/token",
+            client_id=config.client_id,
+        )
+
+    monkeypatch.setattr("conda_auth.cli.perform_oauth_login", perform_oauth_login)
+
+    result = runner.invoke(
+        auth,
+        [
+            "login",
+            "https://repo.example.com/private",
+            "--oauth2",
+            "--oauth-client-id",
+            "client",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.stdout) == {
+        "success": True,
+        "message": SUCCESSFUL_LOGIN_MESSAGE,
+    }
+    assert result.stderr == "Open this URL to authenticate\n"
+
+
+def test_login_token_no_options(monkeypatch, runner, keyring, condarc):
     """
     Test successful login with token without the value being supplied at the command line
     """
@@ -307,7 +352,7 @@ def test_login_token_no_options(mocker, runner, keyring, condarc):
 
     # setup mocks
     keyring(None)
-    mocker.patch("conda_auth.cli.prompt_secret", return_value="token")
+    monkeypatch.setattr("conda_auth.cli.prompt_secret", lambda prompt: "token")
 
     result = runner.invoke(auth, ["login", channel_name, "--token"])
 
@@ -318,8 +363,8 @@ def test_login_token_no_options(mocker, runner, keyring, condarc):
 @pytest.mark.parametrize(
     "option,message",
     (
-        ("--username", "Option 'username' cannot be used with 'token'"),
-        ("--password", "Option 'password' cannot be used with 'token'"),
+        ("--username", "Option 'username' cannot be used with 'token' or 'oauth2'"),
+        ("--password", "Option 'password' cannot be used with 'token' or 'oauth2'"),
     ),
 )
 def test_login_token_rejects_basic_auth_options(runner, keyring, condarc, option, message):

--- a/tests/cli/test_oauth2.py
+++ b/tests/cli/test_oauth2.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from conda.models.channel import Channel
+
+from conda_auth.cli.oauth2 import build_oauth_login_config, ensure_url_scheme
+from conda_auth.exceptions import CondaAuthError
+from conda_auth.oauth2_client import OAuthLoginConfig
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    (
+        ("idp.example.com", "https://idp.example.com"),
+        ("https://idp.example.com", "https://idp.example.com"),
+        ("http://localhost:8080", "http://localhost:8080"),
+    ),
+    ids=("bare-host", "https", "loopback-http"),
+)
+def test_ensure_url_scheme(target, expected):
+    assert ensure_url_scheme(target) == expected
+
+
+def test_build_oauth_login_config_uses_channel_defaults():
+    config = build_oauth_login_config(
+        Channel("https://repo.example.com/private"),
+        {"oauth_client_id": "client"},
+    )
+
+    assert config == OAuthLoginConfig(
+        issuer_url="https://repo.example.com/private",
+        client_id="client",
+    )
+
+
+def test_build_oauth_login_config_uses_explicit_options():
+    output = StringIO()
+
+    config = build_oauth_login_config(
+        Channel("https://repo.example.com/private"),
+        {
+            "oauth_issuer_url": "idp.example.com",
+            "oauth_client_id": "client",
+            "oauth_client_secret": "secret",
+            "oauth_flow": "device-code",
+            "oauth_scopes": ["openid", "offline_access"],
+            "oauth_redirect_uri": "http://localhost:8765/callback",
+            "user_agent": "conda-auth-test",
+            "oauth_output_stream": output,
+        },
+    )
+
+    assert config == OAuthLoginConfig(
+        issuer_url="https://idp.example.com",
+        client_id="client",
+        client_secret="secret",
+        flow="device-code",
+        scopes=("openid", "offline_access"),
+        redirect_uri="http://localhost:8765/callback",
+        user_agent="conda-auth-test",
+        output_stream=output,
+    )
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    (
+        ({"oauth_issuer_url": 1, "oauth_client_id": "client"}, "issuer URL not found"),
+        ({"oauth_client_id": 1}, "client ID not found"),
+        ({"oauth_client_id": "client", "oauth_flow": 1}, "flow must be text"),
+        (
+            {"oauth_client_id": "client", "oauth_client_secret": 1},
+            "client secret must be text",
+        ),
+        (
+            {"oauth_client_id": "client", "oauth_redirect_uri": 1},
+            "redirect URI must be text",
+        ),
+        ({"oauth_client_id": "client", "user_agent": 1}, "user agent must be text"),
+        (
+            {"oauth_client_id": "client", "oauth_output_stream": object()},
+            "output stream must be file-like",
+        ),
+    ),
+    ids=(
+        "issuer",
+        "client-id",
+        "flow",
+        "client-secret",
+        "redirect-uri",
+        "user-agent",
+        "output-stream",
+    ),
+)
+def test_build_oauth_login_config_rejects_invalid_options(options, message):
+    with pytest.raises(CondaAuthError, match=message):
+        build_oauth_login_config(Channel("https://repo.example.com/private"), options)

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -169,3 +169,88 @@ def test_status_displays_credential_expiration(
 
     assert result.exit_code == 0, result.output
     assert result.output == "tester: oauth2 expires_at=3600\n"
+
+
+@pytest.mark.parametrize(
+    ("client_secret_args", "expected_prompt"),
+    (
+        pytest.param(
+            ("--oauth-client-secret", "client-secret"),
+            False,
+            id="argument",
+        ),
+        pytest.param(("--oauth-client-secret",), True, id="prompt"),
+    ),
+)
+def test_oauth_login_uses_explicit_endpoint_options(
+    monkeypatch,
+    runner,
+    keyring,
+    condarc,
+    client_secret_args,
+    expected_prompt,
+):
+    """Generic OAuth login uses caller-supplied endpoint configuration."""
+    keyring(None)
+    seen = {}
+    prompts = []
+
+    def perform_oauth_login(config):
+        seen["config"] = config
+        return CredentialRecord(
+            target="",
+            auth_type="oauth2",
+            username="oauth2",
+            access_token="access-token",
+            refresh_token="refresh-token",
+            token_endpoint="https://idp.example.com/token",
+            revocation_endpoint="https://idp.example.com/revoke",
+            client_id=config.client_id,
+            client_secret=config.client_secret,
+            issuer_url=config.issuer_url,
+            scopes=config.scopes,
+        )
+
+    monkeypatch.setattr("conda_auth.cli.perform_oauth_login", perform_oauth_login)
+    monkeypatch.setattr(
+        "conda_auth.cli.prompt_secret",
+        lambda prompt: prompts.append(prompt) or "client-secret",
+    )
+
+    result = runner.invoke(
+        auth,
+        [
+            "login",
+            "https://repo.example.com/private",
+            "--oauth2",
+            "--oauth-issuer-url",
+            "https://idp.example.com",
+            "--oauth-client-id",
+            "client-id",
+            *client_secret_args,
+            "--oauth-scope",
+            "channel:read",
+            "--oauth-flow",
+            "device-code",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen["config"].issuer_url == "https://idp.example.com"
+    assert seen["config"].client_id == "client-id"
+    assert seen["config"].client_secret == "client-secret"
+    assert seen["config"].flow == "device-code"
+    assert seen["config"].scopes == ("channel:read",)
+    assert prompts == (["OAuth client secret: "] if expected_prompt else [])
+    assert condarc.content == {
+        "channel_settings": [
+            {
+                "channel": "https://repo.example.com/private",
+                "auth": "oauth2",
+                "auth_target": "https://repo.example.com/private",
+            }
+        ]
+    }
+    stored = KeyringStorage().get_credential("https://repo.example.com/private")
+    assert stored is not None
+    assert stored.client_secret == "client-secret"

--- a/tests/handlers/test_oauth2.py
+++ b/tests/handlers/test_oauth2.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import pytest
+from conda.models.channel import Channel
+
+from conda_auth.credentials import CredentialRecord
+from conda_auth.exceptions import CondaAuthError
+from conda_auth.handlers.oauth2 import (
+    OAUTH2_NAME,
+    OAuth2AuthHandler,
+    OAuth2Manager,
+    manager,
+)
+from conda_auth.oauth2_client import OAuthClient, OAuthLoginConfig, validate_oauth_endpoint_url
+from conda_auth.storage import storage
+
+
+@pytest.fixture(autouse=True)
+def clean_up_manager_cache():
+    """Makes sure the manager cache gets emptied after each test run"""
+    context = manager._context
+    yield
+    manager._context = context
+    manager.cache_clear()
+
+
+@dataclass
+class FakeResponse:
+    body: dict[str, object]
+    ok: bool = True
+
+    def json(self):
+        return self.body
+
+
+def test_oauth_handler_refreshes_expired_access_token(
+    monkeypatch,
+    keyring,
+    context_factory,
+    request_factory,
+):
+    """Expired OAuth access tokens are refreshed before request auth is applied."""
+    keyring(None)
+    target = "https://repo.example.com/private"
+    storage.set_credential(
+        CredentialRecord(
+            target=target,
+            auth_type=OAUTH2_NAME,
+            username="oauth2",
+            access_token="old-access-token",
+            refresh_token="refresh-token",
+            expires_at=int(time.time()) - 1,
+            token_endpoint="https://idp.example.com/token",
+            revocation_endpoint="https://idp.example.com/revoke",
+            client_id="client",
+        )
+    )
+    context = context_factory([{"channel": target, "auth": OAUTH2_NAME, "auth_target": target}])
+    monkeypatch.setattr(manager, "_context", context)
+
+    def post(url, data, auth=None, headers=None, timeout=None):
+        assert url == "https://idp.example.com/token"
+        assert data["grant_type"] == "refresh_token"
+        assert auth is None
+        return FakeResponse({"access_token": "new-access-token", "expires_in": 3600})
+
+    monkeypatch.setattr("conda_auth.oauth2_client.requests.post", post)
+
+    request = request_factory()
+    handler = OAuth2AuthHandler(target)
+    handler(request)
+
+    assert request.headers == {"Authorization": "Bearer new-access-token"}
+    stored = storage.get_credential(target)
+    assert stored is not None
+    assert stored.access_token == "new-access-token"
+    assert stored.refresh_token == "refresh-token"
+
+
+def test_oauth_handler_does_not_overwrite_authorization_header(
+    monkeypatch,
+    keyring,
+    context_factory,
+    request_factory,
+):
+    """Existing Authorization headers are preserved."""
+    target = "https://repo.example.com/private"
+    keyring(None)
+    storage.set_credential(
+        CredentialRecord(
+            target=target,
+            auth_type=OAUTH2_NAME,
+            username="oauth2",
+            access_token="access-token",
+        )
+    )
+    context = context_factory([{"channel": target, "auth": OAUTH2_NAME, "auth_target": target}])
+    monkeypatch.setattr(manager, "_context", context)
+    request = request_factory(headers={"Authorization": "Bearer existing"})
+
+    handler = OAuth2AuthHandler(target)
+    handler(request)
+
+    assert request.headers == {"Authorization": "Bearer existing"}
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "https://idp.example.com",
+        "http://localhost:8080",
+        "http://127.0.0.1:8080",
+        "http://[::1]:8080",
+    ),
+    ids=("https", "localhost", "ipv4-loopback", "ipv6-loopback"),
+)
+def test_oauth_endpoint_validation_allows_secure_or_loopback_urls(url):
+    validate_oauth_endpoint_url(url, "issuer URL")
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "http://idp.example.com",
+        "ftp://idp.example.com",
+        "idp.example.com",
+    ),
+    ids=("remote-http", "ftp", "scheme-less"),
+)
+def test_oauth_endpoint_validation_rejects_insecure_urls(url):
+    with pytest.raises(CondaAuthError, match="must use HTTPS or loopback HTTP"):
+        validate_oauth_endpoint_url(url, "issuer URL")
+
+
+@pytest.mark.parametrize(
+    "endpoint_key",
+    (
+        "authorization_endpoint",
+        "token_endpoint",
+        "device_authorization_endpoint",
+        "revocation_endpoint",
+    ),
+)
+def test_oauth_metadata_rejects_insecure_discovered_endpoint(endpoint_key):
+    metadata = {
+        "authorization_endpoint": "https://idp.example.com/authorize",
+        "token_endpoint": "https://idp.example.com/token",
+        "device_authorization_endpoint": "https://idp.example.com/device",
+        "revocation_endpoint": "https://idp.example.com/revoke",
+    }
+    metadata[endpoint_key] = f"http://idp.example.com/{endpoint_key}"
+
+    with pytest.raises(CondaAuthError, match=endpoint_key):
+        OAuthClient(
+            OAuthLoginConfig("https://idp.example.com", "client"),
+            metadata,
+        )
+
+
+def test_oauth_refresh_rejects_insecure_token_endpoint(monkeypatch):
+    def post(url, data, auth=None, headers=None, timeout=None):
+        raise AssertionError(f"Unexpected request to {url}")
+
+    monkeypatch.setattr("conda_auth.oauth2_client.requests.post", post)
+
+    with pytest.raises(CondaAuthError, match="token endpoint"):
+        OAuthClient.refresh_record(
+            CredentialRecord(
+                target="https://repo.example.com/private",
+                auth_type=OAUTH2_NAME,
+                username="oauth2",
+                access_token="old-access-token",
+                refresh_token="refresh-token",
+                expires_at=int(time.time()) - 1,
+                token_endpoint="http://idp.example.com/token",
+                client_id="client",
+            )
+        )
+
+
+def test_oauth_manager_api():
+    oauth_manager = OAuth2Manager()
+    channel = Channel("https://repo.example.com/private")
+
+    assert oauth_manager.get_keyring_id(channel) == (
+        "conda-auth::oauth2::https://repo.example.com/private"
+    )
+    assert oauth_manager.get_auth_type() == OAUTH2_NAME
+    assert oauth_manager.get_auth_class() is OAuth2AuthHandler
+    assert oauth_manager.get_config_parameters() == (
+        "oauth_issuer_url",
+        "oauth_client_id",
+        "oauth_client_secret",
+        "oauth_flow",
+        "oauth_scopes",
+        "oauth_redirect_uri",
+        "user_agent",
+    )
+
+
+@pytest.mark.parametrize(
+    "record",
+    (
+        None,
+        CredentialRecord("target", "token", access_token="access"),
+        CredentialRecord("target", OAUTH2_NAME),
+    ),
+    ids=("missing", "wrong-auth-type", "missing-access-token"),
+)
+def test_oauth_manager_rejects_missing_credentials(
+    monkeypatch,
+    record,
+):
+    oauth_manager = OAuth2Manager()
+    monkeypatch.setattr(
+        oauth_manager,
+        "get_credential_record",
+        lambda channel, settings: record,
+    )
+
+    with pytest.raises(CondaAuthError, match="OAuth credential not found"):
+        oauth_manager.fetch_secret(Channel("tester"), {}, use_cache=False)
+
+
+def test_oauth_manager_rejects_refresh_without_access_token(monkeypatch):
+    oauth_manager = OAuth2Manager()
+    record = CredentialRecord("tester", OAUTH2_NAME, access_token="access")
+    monkeypatch.setattr(
+        oauth_manager,
+        "get_credential_record",
+        lambda channel, settings: record,
+    )
+    monkeypatch.setattr(
+        "conda_auth.handlers.oauth2.refresh_oauth_record",
+        lambda stored: CredentialRecord("tester", OAUTH2_NAME),
+    )
+
+    with pytest.raises(CondaAuthError, match="OAuth credential not found"):
+        oauth_manager.fetch_secret(Channel("tester"), {}, use_cache=False)
+
+
+def test_oauth_manager_removes_and_revokes_credential(monkeypatch):
+    oauth_manager = OAuth2Manager()
+    record = CredentialRecord("tester", OAUTH2_NAME, access_token="access")
+    calls = []
+    monkeypatch.setattr(
+        oauth_manager,
+        "get_credential_record",
+        lambda channel, settings: record,
+    )
+    monkeypatch.setattr(
+        "conda_auth.handlers.oauth2.revoke_oauth_record",
+        lambda stored: calls.append(("revoke", stored)),
+    )
+    monkeypatch.setattr(
+        oauth_manager,
+        "delete_credential_record",
+        lambda channel, settings: calls.append(("delete", channel.canonical_name, settings)),
+    )
+
+    oauth_manager.remove_secret(Channel("tester"), {"auth_target": "tester"})
+
+    assert calls == [
+        ("revoke", record),
+        ("delete", "tester", {"auth_target": "tester"}),
+    ]
+
+
+def test_oauth_manager_removes_missing_credential(monkeypatch):
+    oauth_manager = OAuth2Manager()
+    calls = []
+    monkeypatch.setattr(
+        oauth_manager,
+        "get_credential_record",
+        lambda channel, settings: None,
+    )
+    monkeypatch.setattr(
+        oauth_manager,
+        "delete_credential_record",
+        lambda channel, settings: calls.append((channel.canonical_name, settings)),
+    )
+
+    oauth_manager.remove_secret(Channel("tester"), {})
+
+    assert calls == [("tester", {})]
+
+
+def test_oauth_handler_requires_access_token(monkeypatch):
+    monkeypatch.setattr(manager, "get_secret", lambda channel: (None, None))
+
+    with pytest.raises(CondaAuthError, match="Unable to find OAuth credential"):
+        OAuth2AuthHandler("tester")

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -50,3 +50,18 @@ def test_credential_record_from_dict_normalizes_values(
     assert record.scopes == expected_scopes
     assert record.username == expected_username
     assert record.expires_at == expected_expires_at
+
+
+def test_credential_record_round_trips_oauth_client_secret():
+    record = CredentialRecord(
+        target="tester",
+        auth_type="oauth2",
+        client_id="client",
+        client_secret="secret",
+    )
+
+    serialized = record.to_dict()
+
+    assert serialized["client_secret"] == "secret"
+    assert CredentialRecord.from_dict(serialized) == record
+    assert "client_secret" not in record.to_status_entry()

--- a/tests/test_oauth2_client.py
+++ b/tests/test_oauth2_client.py
@@ -1,0 +1,864 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import socket
+from dataclasses import dataclass, field
+from io import StringIO
+
+import pytest
+import requests
+from conda.models.channel import Channel
+from requests.auth import HTTPBasicAuth
+
+import conda_auth.oauth2_client as oauth2_client
+from conda_auth.credentials import CredentialRecord
+from conda_auth.exceptions import CondaAuthError
+from conda_auth.oauth2_client import (
+    BrowserOpenError,
+    OAuthCallbackServer,
+    OAuthClient,
+    OAuthLoginConfig,
+    OAuthMetadata,
+    OAuthTokens,
+    PKCEChallenge,
+    authorization_code_flow,
+    device_code_flow,
+    discover_oauth_metadata,
+    is_loopback_host,
+    perform_oauth_login,
+    refresh_oauth_record,
+    revoke_oauth_record,
+    scopes_from_value,
+    with_target,
+)
+
+
+@dataclass
+class FakeResponse:
+    body: object
+    status_code: int = 200
+    text: str = ""
+    raise_for_status_calls: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 400
+
+    def json(self) -> object:
+        return self.body
+
+    def raise_for_status(self) -> None:
+        self.raise_for_status_calls += 1
+        if not self.ok:
+            raise requests.HTTPError(response=self)
+
+
+@dataclass
+class CompletedEvent:
+    wait_calls: list[int] = field(default_factory=list)
+
+    def wait(self, timeout: int) -> bool:
+        self.wait_calls.append(timeout)
+        return True
+
+
+@dataclass
+class CallbackStateWithoutResponse:
+    expected_state: str
+    redirect_uri: str
+    authorization_response: str | None = None
+    error: str | None = None
+    completed: CompletedEvent = field(default_factory=CompletedEvent)
+
+
+def test_oauth_metadata_normalizes_and_requires_endpoints():
+    metadata = OAuthMetadata.from_mapping(
+        {
+            "authorization_endpoint": "https://idp.example.com/authorize",
+            "token_endpoint": "https://idp.example.com/token",
+            "device_authorization_endpoint": 123,
+        }
+    )
+
+    assert metadata.authorization_endpoint == "https://idp.example.com/authorize"
+    assert metadata.require("token_endpoint") == "https://idp.example.com/token"
+    assert metadata.device_authorization_endpoint is None
+
+    with pytest.raises(CondaAuthError, match="device_authorization_endpoint"):
+        metadata.require("device_authorization_endpoint")
+
+
+def test_pkce_challenge_uses_s256(monkeypatch):
+    monkeypatch.setattr(oauth2_client.secrets, "token_urlsafe", lambda size: "verifier")
+
+    challenge = PKCEChallenge.create()
+
+    expected = base64.urlsafe_b64encode(hashlib.sha256(b"verifier").digest()).rstrip(b"=").decode()
+    assert challenge == PKCEChallenge(verifier="verifier", challenge=expected)
+
+
+@pytest.mark.parametrize(
+    "redirect_uri",
+    (
+        "https://localhost:8765/callback",
+        "http://example.com:8765/callback",
+        "http://localhost/callback",
+        "http://user@localhost:8765/callback",
+        "http://localhost:8765/callback#fragment",
+    ),
+    ids=("https", "remote-host", "missing-port", "userinfo", "fragment"),
+)
+def test_callback_server_rejects_invalid_redirect_uris(redirect_uri):
+    with pytest.raises(CondaAuthError, match="localhost with an explicit port"):
+        OAuthCallbackServer(redirect_uri)
+
+
+def test_callback_server_accepts_explicit_loopback_redirect():
+    with socket.socket() as listener:
+        listener.bind(("127.0.0.1", 0))
+        port = listener.getsockname()[1]
+
+    redirect_uri = f"http://127.0.0.1:{port}/callback"
+    callback = OAuthCallbackServer(redirect_uri)
+
+    try:
+        assert callback.redirect_uri == redirect_uri
+    finally:
+        callback.server.server_close()
+
+
+def test_callback_server_uses_registered_redirect_origin(monkeypatch):
+    output = StringIO()
+    callback = OAuthCallbackServer(None, output)
+
+    def open_browser(_authorization_url):
+        response = requests.get(
+            f"{callback.redirect_uri}?code=code&state=expected",
+            headers={"Host": "attacker.example.com"},
+            timeout=5,
+        )
+        assert response.status_code == 200
+        return True
+
+    monkeypatch.setattr(oauth2_client.webbrowser, "open", open_browser)
+
+    authorization_response = callback.wait_for_authorization_response(
+        "https://idp.example.com/authorize",
+        "expected",
+    )
+
+    assert authorization_response == f"{callback.redirect_uri}?code=code&state=expected"
+    assert "attacker.example.com" not in authorization_response
+    assert output.getvalue() == (
+        "Opening browser at:\n\nhttps://idp.example.com/authorize\n"
+        "Waiting for authentication in browser...\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("callback_path", "message"),
+    (
+        ("unexpected?code=code&state=expected", "callback path did not match"),
+        ("?code=code&state=wrong", "callback state did not match"),
+        ("?error=access_denied&state=expected", "access_denied"),
+    ),
+    ids=("wrong-path", "wrong-state", "provider-error"),
+)
+def test_callback_server_rejects_invalid_authorization_responses(
+    monkeypatch,
+    callback_path,
+    message,
+):
+    callback = OAuthCallbackServer(None)
+
+    def open_browser(_authorization_url):
+        requests.get(f"{callback.redirect_uri}{callback_path}", timeout=5)
+        return True
+
+    monkeypatch.setattr(oauth2_client.webbrowser, "open", open_browser)
+
+    with pytest.raises(CondaAuthError, match=message):
+        callback.wait_for_authorization_response(
+            "https://idp.example.com/authorize",
+            "expected",
+        )
+
+
+def test_callback_server_reports_browser_open_failure(monkeypatch):
+    callback = OAuthCallbackServer(None)
+    monkeypatch.setattr(oauth2_client.webbrowser, "open", lambda url: False)
+
+    with pytest.raises(BrowserOpenError, match="Unable to open browser"):
+        callback.wait_for_authorization_response(
+            "https://idp.example.com/authorize",
+            "expected",
+        )
+
+
+def test_callback_server_reports_timeout(monkeypatch):
+    callback = OAuthCallbackServer(None)
+    monkeypatch.setattr(oauth2_client.webbrowser, "open", lambda url: True)
+    monkeypatch.setattr(oauth2_client, "OAUTH_CALLBACK_TIMEOUT_SECONDS", 0)
+
+    with pytest.raises(CondaAuthError, match="Timed out waiting"):
+        callback.wait_for_authorization_response(
+            "https://idp.example.com/authorize",
+            "expected",
+        )
+
+
+def test_callback_server_requires_authorization_response(monkeypatch):
+    callback = OAuthCallbackServer(None)
+    monkeypatch.setattr(oauth2_client.webbrowser, "open", lambda url: True)
+    monkeypatch.setattr(oauth2_client, "_CallbackState", CallbackStateWithoutResponse)
+
+    with pytest.raises(CondaAuthError, match="did not include an authorization response"):
+        callback.wait_for_authorization_response(
+            "https://idp.example.com/authorize",
+            "expected",
+        )
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_error"),
+    (
+        (
+            {
+                "authorization_endpoint": "https://idp.example.com/authorize",
+                "token_endpoint": "https://idp.example.com/token",
+            },
+            None,
+        ),
+        (["invalid"], "discovery response is invalid"),
+    ),
+    ids=("valid", "invalid"),
+)
+def test_discover_oauth_metadata(monkeypatch, body, expected_error):
+    response = FakeResponse(body)
+    calls = []
+
+    def get(url, headers, timeout):
+        calls.append((url, headers, timeout))
+        return response
+
+    monkeypatch.setattr(oauth2_client.requests, "get", get)
+    config = OAuthLoginConfig(
+        "https://idp.example.com/",
+        "client",
+        user_agent="conda-auth-test",
+    )
+
+    if expected_error is not None:
+        with pytest.raises(CondaAuthError, match=expected_error):
+            discover_oauth_metadata(config)
+    else:
+        assert discover_oauth_metadata(config) == body
+
+    assert calls == [
+        (
+            "https://idp.example.com/.well-known/openid-configuration",
+            {"User-Agent": "conda-auth-test"},
+            30,
+        )
+    ]
+    assert response.raise_for_status_calls == 1
+
+
+@pytest.mark.parametrize(
+    ("flow", "auth_result", "expected_calls"),
+    (
+        ("auth-code", OAuthTokens("access", token_endpoint="https://idp/token"), ["auth"]),
+        ("device-code", OAuthTokens("access", token_endpoint="https://idp/token"), ["device"]),
+        ("auto", OAuthTokens("access", token_endpoint="https://idp/token"), ["auth"]),
+        ("auto", BrowserOpenError("no browser"), ["auth", "device"]),
+    ),
+    ids=("auth-code", "device-code", "auto-auth-code", "auto-device-fallback"),
+)
+def test_oauth_client_login_selects_flow(monkeypatch, flow, auth_result, expected_calls):
+    calls = []
+    device_result = OAuthTokens(
+        "device-access",
+        refresh_token="refresh",
+        expires_at=100,
+        token_endpoint="https://idp/token",
+        revocation_endpoint="https://idp/revoke",
+    )
+
+    def auth_code(client):
+        calls.append("auth")
+        if isinstance(auth_result, Exception):
+            raise auth_result
+        return auth_result
+
+    def device_code(client):
+        calls.append("device")
+        return device_result
+
+    monkeypatch.setattr(OAuthClient, "authorization_code_flow", auth_code)
+    monkeypatch.setattr(OAuthClient, "device_code_flow", device_code)
+    config = OAuthLoginConfig(
+        "https://idp.example.com",
+        "client",
+        client_secret="secret",
+        flow=flow,
+        scopes=("openid",),
+    )
+
+    record = OAuthClient(config, {}).login()
+
+    assert calls == expected_calls
+    assert record.auth_type == "oauth2"
+    assert record.client_id == "client"
+    assert record.client_secret == "secret"
+    assert record.issuer_url == "https://idp.example.com"
+    assert record.scopes == ("openid",)
+    if expected_calls[-1] == "device":
+        assert record.access_token == "device-access"
+        assert record.refresh_token == "refresh"
+    else:
+        assert record.access_token == "access"
+
+
+@pytest.mark.parametrize(
+    ("flow", "tokens", "message"),
+    (
+        ("password", OAuthTokens("access", token_endpoint="https://idp/token"), "must be one of"),
+        ("auth-code", OAuthTokens("access"), "token endpoint not found"),
+    ),
+    ids=("invalid-flow", "missing-token-endpoint"),
+)
+def test_oauth_client_login_rejects_invalid_results(monkeypatch, flow, tokens, message):
+    monkeypatch.setattr(OAuthClient, "authorization_code_flow", lambda client: tokens)
+    client = OAuthClient(OAuthLoginConfig("https://idp.example.com", "client", flow=flow), {})
+
+    with pytest.raises(CondaAuthError, match=message):
+        client.login()
+
+
+@pytest.mark.parametrize("client_secret", (None, "secret"), ids=("public", "confidential"))
+def test_authorization_code_flow_uses_pkce(monkeypatch, client_secret):
+    calls = []
+
+    class FakeCallback:
+        def __init__(self, redirect_uri, output_stream):
+            calls.append(("callback", redirect_uri, output_stream))
+            self.redirect_uri = "http://127.0.0.1:8765/callback"
+
+        def wait_for_authorization_response(self, authorization_url, state):
+            calls.append(("wait", authorization_url, state))
+            return f"{self.redirect_uri}?code=code&state={state}"
+
+    class FakeOAuth2Session:
+        def __init__(self, client_id, secret, scope, redirect_uri):
+            calls.append(("session", client_id, secret, scope, redirect_uri))
+
+        def create_authorization_url(self, url, **kwargs):
+            calls.append(("authorize", url, kwargs))
+            return "https://idp.example.com/authorize?state=state", "state"
+
+        def fetch_token(self, url, **kwargs):
+            calls.append(("token", url, kwargs))
+            return {"access_token": "access", "refresh_token": "refresh"}
+
+    monkeypatch.setattr(oauth2_client, "OAuthCallbackServer", FakeCallback)
+    monkeypatch.setattr(
+        oauth2_client.PKCEChallenge,
+        "create",
+        classmethod(lambda cls: PKCEChallenge("verifier", "challenge")),
+    )
+    monkeypatch.setattr(
+        "authlib.integrations.requests_client.OAuth2Session",
+        FakeOAuth2Session,
+    )
+    config = OAuthLoginConfig(
+        "https://idp.example.com",
+        "client",
+        client_secret=client_secret,
+        scopes=("openid", "offline_access"),
+        redirect_uri="http://localhost:8765/callback",
+    )
+    metadata = {
+        "authorization_endpoint": "https://idp.example.com/authorize",
+        "token_endpoint": "https://idp.example.com/token",
+        "revocation_endpoint": "https://idp.example.com/revoke",
+    }
+
+    tokens = authorization_code_flow(config, metadata)
+
+    assert tokens == OAuthTokens(
+        access_token="access",
+        refresh_token="refresh",
+        token_endpoint="https://idp.example.com/token",
+        revocation_endpoint="https://idp.example.com/revoke",
+    )
+    assert (
+        "session",
+        "client",
+        client_secret,
+        "openid offline_access",
+        "http://127.0.0.1:8765/callback",
+    ) in calls
+    token_call = next(call for call in calls if call[0] == "token")
+    assert token_call[2]["code_verifier"] == "verifier"
+    assert token_call[2]["include_client_id"] is (client_secret is None)
+
+
+def test_device_code_flow_polls_until_authorized(monkeypatch):
+    responses = [
+        FakeResponse(
+            {
+                "verification_uri": "https://idp.example.com/device",
+                "user_code": "ABCD",
+                "device_code": "device",
+                "interval": 1,
+                "expires_in": 60,
+            }
+        ),
+        FakeResponse({"error": "authorization_pending"}, status_code=400),
+        FakeResponse({"error": "slow_down"}, status_code=400),
+        FakeResponse(
+            {"access_token": "access", "refresh_token": "refresh"},
+            status_code=200,
+        ),
+    ]
+    calls = []
+    sleeps = []
+    output = StringIO()
+
+    def post(url, data, headers, timeout):
+        calls.append((url, data, headers, timeout))
+        return responses.pop(0)
+
+    monkeypatch.setattr(oauth2_client.requests, "post", post)
+    monkeypatch.setattr(oauth2_client.time, "time", lambda: 100)
+    monkeypatch.setattr(oauth2_client.time, "sleep", sleeps.append)
+    config = OAuthLoginConfig(
+        "https://idp.example.com",
+        "client",
+        flow="device-code",
+        scopes=("openid",),
+        user_agent="conda-auth-test",
+        output_stream=output,
+    )
+    metadata = {
+        "token_endpoint": "https://idp.example.com/token",
+        "device_authorization_endpoint": "https://idp.example.com/device",
+        "revocation_endpoint": "https://idp.example.com/revoke",
+    }
+
+    tokens = device_code_flow(config, metadata)
+
+    assert tokens == OAuthTokens(
+        access_token="access",
+        refresh_token="refresh",
+        token_endpoint="https://idp.example.com/token",
+        revocation_endpoint="https://idp.example.com/revoke",
+    )
+    assert sleeps == [1, 1, 6]
+    assert calls[0][1] == {"client_id": "client", "scope": "openid"}
+    assert calls[-1][1]["grant_type"] == "urn:ietf:params:oauth:grant-type:device_code"
+    assert output.getvalue() == (
+        "Open this URL to authenticate:\n\nhttps://idp.example.com/device\nEnter code: ABCD\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "device_data", "expires_in", "message"),
+    (
+        ({"token_endpoint": "https://idp/token"}, None, None, "does not support"),
+        (
+            {
+                "token_endpoint": "https://idp/token",
+                "device_authorization_endpoint": "https://idp/device",
+            },
+            {"device_code": "device"},
+            None,
+            "verification URI",
+        ),
+        (
+            {
+                "token_endpoint": "https://idp/token",
+                "device_authorization_endpoint": "https://idp/device",
+            },
+            {"verification_uri_complete": "https://idp/verify"},
+            None,
+            "device code",
+        ),
+        (
+            {
+                "token_endpoint": "https://idp/token",
+                "device_authorization_endpoint": "https://idp/device",
+            },
+            {
+                "verification_uri": "https://idp/verify",
+                "device_code": "device",
+                "expires_in": 0,
+            },
+            0,
+            "Timed out",
+        ),
+    ),
+    ids=("unsupported", "missing-verification", "missing-code", "timeout"),
+)
+def test_device_code_flow_rejects_invalid_responses(
+    monkeypatch,
+    metadata,
+    device_data,
+    expires_in,
+    message,
+):
+    if device_data is not None:
+        monkeypatch.setattr(
+            oauth2_client.requests,
+            "post",
+            lambda url, data, headers, timeout: FakeResponse(device_data),
+        )
+    monkeypatch.setattr(oauth2_client.time, "time", lambda: 100)
+    monkeypatch.setattr(oauth2_client.time, "sleep", lambda interval: None)
+    config = OAuthLoginConfig("https://idp.example.com", "client", flow="device-code")
+
+    with pytest.raises(CondaAuthError, match=message):
+        device_code_flow(config, metadata)
+
+
+def test_device_code_flow_reports_provider_error(monkeypatch):
+    responses = [
+        FakeResponse(
+            {
+                "verification_uri": "https://idp/verify",
+                "device_code": "device",
+                "interval": 0,
+            }
+        ),
+        FakeResponse({}, status_code=400, text="provider failure"),
+    ]
+    monkeypatch.setattr(
+        oauth2_client.requests,
+        "post",
+        lambda url, data, headers, timeout: responses.pop(0),
+    )
+    monkeypatch.setattr(oauth2_client.time, "time", lambda: 100)
+    monkeypatch.setattr(oauth2_client.time, "sleep", lambda interval: None)
+    metadata = {
+        "token_endpoint": "https://idp/token",
+        "device_authorization_endpoint": "https://idp/device",
+    }
+
+    with pytest.raises(CondaAuthError, match="provider failure"):
+        device_code_flow(
+            OAuthLoginConfig("https://idp.example.com", "client", flow="device-code"),
+            metadata,
+        )
+
+
+@pytest.mark.parametrize(
+    "record",
+    (
+        CredentialRecord("target", "token", expires_at=0),
+        CredentialRecord("target", "oauth2"),
+        CredentialRecord("target", "oauth2", expires_at=10_000),
+        CredentialRecord("target", "oauth2", expires_at=0, token_endpoint="https://idp/token"),
+        CredentialRecord("target", "oauth2", expires_at=0, refresh_token="refresh"),
+        CredentialRecord(
+            "target",
+            "oauth2",
+            expires_at=0,
+            refresh_token="refresh",
+            token_endpoint="https://idp/token",
+        ),
+    ),
+    ids=(
+        "wrong-auth-type",
+        "missing-expiry",
+        "not-expiring",
+        "missing-refresh-token",
+        "missing-token-endpoint",
+        "missing-client-id",
+    ),
+)
+def test_refresh_record_skips_ineligible_credentials(monkeypatch, record):
+    def unexpected_post(*args, **kwargs):
+        raise AssertionError("unexpected refresh request")
+
+    monkeypatch.setattr(oauth2_client.time, "time", lambda: 1_000)
+    monkeypatch.setattr(oauth2_client.requests, "post", unexpected_post)
+
+    assert refresh_oauth_record(record) is record
+
+
+@pytest.mark.parametrize(
+    ("client_secret", "response", "expected_refresh_token"),
+    (
+        (None, FakeResponse({"access_token": "new", "expires_in": 3600}), "old-refresh"),
+        (
+            "secret",
+            FakeResponse(
+                {
+                    "access_token": "new",
+                    "refresh_token": "new-refresh",
+                    "expires_in": 3600,
+                }
+            ),
+            "new-refresh",
+        ),
+    ),
+    ids=("public-client", "confidential-client"),
+)
+def test_refresh_record_updates_tokens(
+    monkeypatch,
+    client_secret,
+    response,
+    expected_refresh_token,
+):
+    calls = []
+
+    def post(url, data, auth, headers, timeout):
+        calls.append((url, data, auth, headers, timeout))
+        return response
+
+    monkeypatch.setattr(oauth2_client.requests, "post", post)
+    monkeypatch.setattr(oauth2_client.time, "time", lambda: 1_000)
+    record = CredentialRecord(
+        target="target",
+        auth_type="oauth2",
+        access_token="old",
+        refresh_token="old-refresh",
+        expires_at=999,
+        token_endpoint="https://idp.example.com/token",
+        revocation_endpoint="https://idp.example.com/revoke",
+        client_id="client",
+        client_secret=client_secret,
+        issuer_url="https://idp.example.com",
+        scopes=("openid",),
+    )
+
+    refreshed = refresh_oauth_record(record, user_agent="conda-auth-test")
+
+    assert refreshed.access_token == "new"
+    assert refreshed.refresh_token == expected_refresh_token
+    assert refreshed.expires_at == 4_600
+    assert refreshed.client_secret == client_secret
+    _, data, auth, headers, timeout = calls[0]
+    assert data["grant_type"] == "refresh_token"
+    assert headers == {"User-Agent": "conda-auth-test"}
+    assert timeout == 30
+    if client_secret is None:
+        assert data["client_id"] == "client"
+        assert auth is None
+    else:
+        assert "client_id" not in data
+        assert isinstance(auth, HTTPBasicAuth)
+        assert auth.username == "client"
+        assert auth.password == "secret"
+
+
+def test_refresh_record_keeps_credentials_after_http_failure(monkeypatch):
+    record = CredentialRecord(
+        target="target",
+        auth_type="oauth2",
+        access_token="old",
+        refresh_token="refresh",
+        expires_at=0,
+        token_endpoint="https://idp.example.com/token",
+        client_id="client",
+    )
+    monkeypatch.setattr(
+        oauth2_client.requests,
+        "post",
+        lambda *args, **kwargs: FakeResponse({}, status_code=401),
+    )
+
+    assert refresh_oauth_record(record) is record
+
+
+@pytest.mark.parametrize(
+    "record",
+    (
+        CredentialRecord("target", "oauth2", access_token="access"),
+        CredentialRecord(
+            "target",
+            "oauth2",
+            revocation_endpoint="https://idp.example.com/revoke",
+        ),
+        CredentialRecord(
+            "target",
+            "oauth2",
+            access_token="access",
+            revocation_endpoint="http://idp.example.com/revoke",
+        ),
+    ),
+    ids=("missing-endpoint", "missing-token", "insecure-endpoint"),
+)
+def test_revoke_record_skips_ineligible_credentials(monkeypatch, record):
+    def unexpected_post(*args, **kwargs):
+        raise AssertionError("unexpected revocation request")
+
+    monkeypatch.setattr(oauth2_client.requests, "post", unexpected_post)
+
+    revoke_oauth_record(record)
+
+
+@pytest.mark.parametrize("client_secret", (None, "secret"), ids=("public", "confidential"))
+def test_revoke_record_uses_refresh_token_and_client_auth(monkeypatch, client_secret):
+    calls = []
+
+    def post(url, data, auth, headers, timeout):
+        calls.append((url, data, auth, headers, timeout))
+        return FakeResponse({})
+
+    monkeypatch.setattr(oauth2_client.requests, "post", post)
+    record = CredentialRecord(
+        target="target",
+        auth_type="oauth2",
+        access_token="access",
+        refresh_token="refresh",
+        revocation_endpoint="https://idp.example.com/revoke",
+        client_id="client",
+        client_secret=client_secret,
+    )
+
+    revoke_oauth_record(record, user_agent="conda-auth-test")
+
+    _, data, auth, headers, timeout = calls[0]
+    assert data["token"] == "refresh"
+    assert headers == {"User-Agent": "conda-auth-test"}
+    assert timeout == 30
+    if client_secret is None:
+        assert data["client_id"] == "client"
+        assert auth is None
+    else:
+        assert "client_id" not in data
+        assert isinstance(auth, HTTPBasicAuth)
+
+
+def test_revoke_record_ignores_network_failure(monkeypatch):
+    def post(*args, **kwargs):
+        raise requests.ConnectionError("offline")
+
+    monkeypatch.setattr(oauth2_client.requests, "post", post)
+    record = CredentialRecord(
+        target="target",
+        auth_type="oauth2",
+        access_token="access",
+        revocation_endpoint="https://idp.example.com/revoke",
+        client_id="client",
+    )
+
+    revoke_oauth_record(record)
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    (
+        (
+            {"access_token": "access", "refresh_token": "refresh", "expires_in": 60},
+            OAuthTokens(
+                "access",
+                refresh_token="refresh",
+                expires_at=1_060,
+                token_endpoint="https://idp/token",
+                revocation_endpoint="https://idp/revoke",
+            ),
+        ),
+        (
+            {"access_token": "access", "refresh_token": 123, "expires_in": "60"},
+            OAuthTokens(
+                "access",
+                token_endpoint="https://idp/token",
+                revocation_endpoint="https://idp/revoke",
+            ),
+        ),
+    ),
+    ids=("complete", "optional-values-invalid"),
+)
+def test_tokens_from_response(monkeypatch, data, expected):
+    monkeypatch.setattr(oauth2_client.time, "time", lambda: 1_000)
+
+    assert (
+        OAuthClient.tokens_from_response(
+            data,
+            "https://idp/token",
+            "https://idp/revoke",
+        )
+        == expected
+    )
+
+
+def test_tokens_from_response_requires_access_token():
+    with pytest.raises(CondaAuthError, match="access token"):
+        OAuthClient.tokens_from_response({}, "https://idp/token", None)
+
+
+def test_oauth_wrapper_functions(monkeypatch):
+    config = OAuthLoginConfig("https://idp.example.com", "client")
+    expected_record = CredentialRecord("target", "oauth2", access_token="access")
+    calls = []
+
+    class FakeClient:
+        def login(self):
+            calls.append("login")
+            return expected_record
+
+    monkeypatch.setattr(OAuthClient, "discover", lambda supplied: FakeClient())
+    monkeypatch.setattr(
+        OAuthClient,
+        "refresh_record",
+        lambda record, user_agent=None: expected_record,
+    )
+    monkeypatch.setattr(
+        OAuthClient,
+        "revoke_record",
+        lambda record, user_agent=None: calls.append((record, user_agent)),
+    )
+
+    assert perform_oauth_login(config) is expected_record
+    assert refresh_oauth_record(expected_record, "agent") is expected_record
+    revoke_oauth_record(expected_record, "agent")
+    assert calls == ["login", (expected_record, "agent")]
+
+
+def test_oauth_client_discover_builds_client(monkeypatch):
+    config = OAuthLoginConfig("https://idp.example.com", "client")
+    metadata = {"token_endpoint": "https://idp.example.com/token"}
+    monkeypatch.setattr(OAuthClient, "discover_metadata", lambda supplied: metadata)
+
+    client = OAuthClient.discover(config)
+
+    assert client.config is config
+    assert client.metadata.token_endpoint == "https://idp.example.com/token"
+
+
+def test_with_target_uses_channel_canonical_name():
+    record = CredentialRecord("", "oauth2", access_token="access")
+
+    assert with_target(record, Channel("https://repo.example.com/private")).target == (
+        "https://repo.example.com/private"
+    )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        (None, ()),
+        ("openid", ("openid",)),
+        (["openid", 1], ("openid", "1")),
+        (123, ()),
+    ),
+    ids=("none", "string", "sequence", "invalid"),
+)
+def test_scopes_from_value(value, expected):
+    assert scopes_from_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    (
+        (None, False),
+        ("localhost", True),
+        ("127.0.0.1", True),
+        ("example.com", False),
+    ),
+)
+def test_is_loopback_host(host, expected):
+    assert is_loopback_host(host) is expected

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import subprocess
 import sys
 
+import pytest
+
 from conda_auth import plugin
 from conda_auth.cli import configure_parser
 from conda_auth.handlers import (
     HTTP_BASIC_AUTH_NAME,
+    OAUTH2_NAME,
     TOKEN_NAME,
     BasicAuthHandler,
+    OAuth2AuthHandler,
     TokenAuthHandler,
 )
 
@@ -24,17 +28,22 @@ def test_conda_subcommands_hook():
     assert objs[0].configure_parser is configure_parser
 
 
-def test_conda_auth_handlers_hook():
-    """
-    Test to make sure that this hook yields the correct objects.
-    """
+@pytest.mark.parametrize(
+    ("index", "name", "handler"),
+    (
+        (0, HTTP_BASIC_AUTH_NAME, BasicAuthHandler),
+        (1, TOKEN_NAME, TokenAuthHandler),
+        (2, OAUTH2_NAME, OAuth2AuthHandler),
+    ),
+    ids=("basic-auth", "token", "oauth2"),
+)
+def test_conda_auth_handlers_hook(index, name, handler):
+    """The auth handler hook registers supported auth schemes."""
+    # Hook order is part of the registration surface conda sees.
     objs = list(plugin.conda_auth_handlers())
 
-    assert objs[0].name == HTTP_BASIC_AUTH_NAME
-    assert objs[0].handler == BasicAuthHandler
-
-    assert objs[1].name == TOKEN_NAME
-    assert objs[1].handler == TokenAuthHandler
+    assert objs[index].name == name
+    assert objs[index].handler == handler
 
 
 def test_plugin_import_does_not_eagerly_import_runtime_modules():


### PR DESCRIPTION
## Summary
- Adds generic OAuth2/OIDC endpoint authentication with browser and device-code flows, refresh, and logout revocation support.

## Review Order
This PR is part of #42. Review this PR before #62.

## Chain Tracker
- Previous: #60 Refactor auth CLI into package
- Current: #61 Add OAuth2 endpoint authentication
- Next: #62 Support configurable token headers
- Status: ready for review

## Issues
- Closes #7
