### PR TITLE
Fix canary package builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,8 +96,6 @@ jobs:
         include:
           - runner: ubuntu-latest
             subdir: noarch
-    env:
-      CONDA_SOLVER: classic
     runs-on: ${{ matrix.runner }}
     steps:
       # Clean checkout of specific git ref needed for package metadata version

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-auth
-  version: {{ GIT_DESCRIBE_TAG }}.{{ GIT_BUILD_STR }}
+  version: {{ GIT_DESCRIBE_TAG_PEP440 }}
 
 source:
   git_url: ../


### PR DESCRIPTION
## Summary
- Let canary builds use conda’s default libmamba solver instead of forcing the classic solver.
- Generate PEP 440-compatible canary versions for Hatch VCS.

## Context
The `main` canary job currently fails while resolving conda virtual packages. Once that is corrected, the legacy recipe produces an underscore-based version that Hatch rejects.